### PR TITLE
fix: 修复微信图文同步的接口请求异常问题

### DIFF
--- a/packages/@wechatsync/drivers/src/weixin.js
+++ b/packages/@wechatsync/drivers/src/weixin.js
@@ -46,14 +46,14 @@ export default class WeixinAdapter {
       post_id: 0,
     }
   }
-  
+
   async searchAccount({ keyword, begin=0, count=5 }) {
     var token = weixinMetaCache.token || '442135330'
     const apiURL = `https://mp.weixin.qq.com/cgi-bin/searchbiz?action=search_biz&begin=${begin}&count=${count}&query=${encodeURIComponent(keyword)}&token=${token}&lang=zh_CN&f=json&ajax=1`
     const response = await $.get(apiURL)
     return response
   }
-  
+
   async listArticle({ fakeid = '', begin=0, count=5}) {
   	var token = weixinMetaCache.token || '442135330'
     const apiURL = `https://mp.weixin.qq.com/cgi-bin/appmsg?action=list_ex&begin=${begin}&count=${count}&fakeid=${fakeid}&type=9&query=&token=${token}&lang=zh_CN&f=json&ajax=1`
@@ -102,7 +102,7 @@ export default class WeixinAdapter {
     console.log('editPost', post.post_thumbnail)
     var res = await $.ajax({
       url:
-        'https://mp.weixin.qq.com/cgi-bin/operate_appmsg?t=ajax-response&sub=create&type=10&token=' +
+        'https://mp.weixin.qq.com/cgi-bin/operate_appmsg?t=ajax-response&sub=create&type=77&token=' +
         weixinMetaCache.token +
         '&lang=zh_CN',
       type: 'POST',


### PR DESCRIPTION
背景：定位到微信公众号平台正对草稿箱进行了更新，图文创建API存在修改导致同步失败

[fix](https://github.com/wechatsync/Wechatsync/issues/79) 问题