### PR TITLE
docs: update Chrome Web Store URL to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 ### Chrome 浏览器扩展安装
 
-**推荐**: [Chrome 网上应用店](https://chrome.google.com/webstore/detail/%E5%BE%AE%E4%BF%A1%E5%90%8C%E6%AD%A5%E5%8A%A9%E6%89%8B/hchobocdmclopcbnibdnoafilagadion) (自动更新)
+**推荐**: [Chrome 网上应用店](https://chromewebstore.google.com/detail/%E5%BE%AE%E4%BF%A1%E5%90%8C%E6%AD%A5%E5%8A%A9%E6%89%8B/hchobocdmclopcbnibdnoafilagadion) (自动更新)
 
 **手动安装**: 下载 [最新 Release](https://wpics.oss-cn-shanghai.aliyuncs.com/wechatsync-2.0.6.zip?date=20260225) 解压后加载到 Chrome 扩展
 


### PR DESCRIPTION
## Summary
- Updated 1 Chrome Web Store URL in README.md from `chrome.google.com/webstore` to `chromewebstore.google.com`
- Google migrated the Chrome Web Store to this new domain; the old URL redirects but should be updated for consistency

## Test plan
- [x] Verified updated URL resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)