### PR TITLE
fix: 修复 CSDN JSON 代码块格式错乱问题

### DIFF
--- a/packages/core/src/lib/turndown.ts
+++ b/packages/core/src/lib/turndown.ts
@@ -228,19 +228,38 @@ export interface TurndownOptions {
 }
 
 /**
+ * 规范化单元格内容
+ * markdown 表格要求每行单元格在同一行，且 `|` 需转义
+ * - 去首尾空白
+ * - 转义管道符
+ * - 换行 → <br>（保留视觉换行；CSDN/标准 markdown 渲染器在表格单元格内支持 <br>）
+ * - 合并多余空白
+ * - 空内容补足占位（避免某些渲染器折叠列）
+ */
+function normalizeCellContent(content: string): string {
+  let result = content.replace(/^\s+|\s+$/g, '')
+  result = result.replace(/\|+/g, '\\|')
+  result = result.replace(/\s*\r?\n\s*/g, '<br>')
+  result = result.replace(/[ \t]{2,}/g, ' ')
+  while (result.length < 3) result += ' '
+  return result
+}
+
+/**
  * 表格单元格处理
  */
 function cell(content: string, node: Element): string {
+  const normalized = normalizeCellContent(content)
   // 计算元素在兄弟元素中的位置
   // 使用 querySelectorAll 获取所有同级 th/td（更可靠）
   const parent = node.parentNode as Element | null
   if (!parent) {
-    return '| ' + content + ' |'
+    return '| ' + normalized + ' |'
   }
   const siblings = parent.querySelectorAll('th, td')
   const index = Array.from(siblings).indexOf(node)
   const prefix = index === 0 ? '| ' : ' '
-  return prefix + content + ' |'
+  return prefix + normalized + ' |'
 }
 
 /**

--- a/packages/core/src/lib/turndown.ts
+++ b/packages/core/src/lib/turndown.ts
@@ -234,14 +234,12 @@ export interface TurndownOptions {
  * - 转义管道符
  * - 换行 → <br>（保留视觉换行；CSDN/标准 markdown 渲染器在表格单元格内支持 <br>）
  * - 合并多余空白
- * - 空内容补足占位（避免某些渲染器折叠列）
  */
 function normalizeCellContent(content: string): string {
   let result = content.replace(/^\s+|\s+$/g, '')
-  result = result.replace(/\|+/g, '\\|')
+  result = result.replace(/\|/g, '\\|')
   result = result.replace(/\s*\r?\n\s*/g, '<br>')
   result = result.replace(/[ \t]{2,}/g, ' ')
-  while (result.length < 3) result += ' '
   return result
 }
 

--- a/packages/extension/src/lib/content-processor.ts
+++ b/packages/extension/src/lib/content-processor.ts
@@ -368,7 +368,7 @@ function removeLineNumberSiblings(pre: Element): void {
  * 可作为代码行容器的标签
  * 这些标签通常用于包裹单行代码
  */
-const LINE_CONTAINER_TAGS = new Set(['CODE', 'DIV', 'SPAN', 'P', 'LI'])
+const LINE_CONTAINER_TAGS = new Set(['CODE', 'DIV', 'P', 'LI'])
 
 /**
  * 检查子元素是否构成有效的"多行结构"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,5 @@
 packages:
   - packages/*
 
-allowBuilds:
-  esbuild: set this to true or false
-
 ignoredBuiltDependencies:
   - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,8 @@
 packages:
   - packages/*
 
+allowBuilds:
+  esbuild: set this to true or false
+
 ignoredBuiltDependencies:
   - esbuild


### PR DESCRIPTION
从 LINE_CONTAINER_TAGS 移除 SPAN，避免 Prism.js 高亮后的 token span 被误判为"每行一个元素"的多行结构，导致 JSON 每个 token 各占一行。
同时优化表格单元格内容规范化（normalizeCellContent）。