### PR TITLE
[codex] Guard recovered sync platform selections

### DIFF
--- a/packages/extension/src/popup/stores/sync.ts
+++ b/packages/extension/src/popup/stores/sync.ts
@@ -208,7 +208,7 @@ export const useSyncStore = create<SyncState>((set, get) => ({
         set({
           status: syncState.status,
           article: syncState.article,
-          selectedPlatforms: syncState.selectedPlatforms,
+          selectedPlatforms: Array.isArray(syncState.selectedPlatforms) ? syncState.selectedPlatforms : [],
           results: syncState.results || [],
           currentSyncId: syncState.syncId || null,
           recovered: true,


### PR DESCRIPTION
## Summary
- normalize recovered `selectedPlatforms` before writing it back into the popup store
- fall back to an empty selection when older persisted sync state does not contain an array

This prevents the popup from later reading `.length` from an undefined recovered selection. This may help with #194, where the sync action fails before a backend request is made.

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @wechatsync/extension typecheck`