### PR TITLE
[codex] Render Zhihu LaTeX equations

### DIFF
--- a/packages/core/src/adapters/platforms/__tests__/zhihu.test.ts
+++ b/packages/core/src/adapters/platforms/__tests__/zhihu.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { ZhihuAdapter } from '../zhihu'
+
+describe('ZhihuAdapter', () => {
+  it('renders markdown latex as Zhihu equation images', () => {
+    const adapter = new ZhihuAdapter()
+    const transformContent = (
+      adapter as unknown as { transformContent(content: string): string }
+    ).transformContent.bind(adapter)
+
+    const html = [
+      '<p>行内 $111$ 公式</p>',
+      '<p>$$x^2 + y^2$$</p>',
+      '<p><img src="https://example.com/a.png"></p>',
+      '<pre><code>$keep$</code></pre>',
+    ].join('')
+
+    const result = transformContent(html)
+
+    expect(result).toContain('https://www.zhihu.com/equation?tex=111')
+    expect(result).toContain('eeimg="1"')
+    expect(result).toContain('https://www.zhihu.com/equation?tex=x%5E2%20%2B%20y%5E2')
+    expect(result).toContain('eeimg="2"')
+    expect(result).toContain('<figure><img src="https://example.com/a.png"></figure>')
+    expect(result).toContain('<pre><code>$keep$</code></pre>')
+  })
+})

--- a/packages/core/src/adapters/platforms/zhihu.ts
+++ b/packages/core/src/adapters/platforms/zhihu.ts
@@ -197,23 +197,58 @@ export class ZhihuAdapter extends CodeAdapter {
     // 1. 转换表格格式 - 知乎 Draft.js 编辑器需要特定格式
     result = this.transformTables(result)
 
-    // 2. 图片格式 - 知乎需要 figure 包裹
+    // 2. LaTeX 公式 - 知乎编辑器使用 equation 图片
+    result = this.transformLatex(result)
+
+    // 3. 图片格式 - 知乎需要 figure 包裹
     result = result.replace(
       /<img([^>]+)src="([^"]+)"([^>]*)>/gi,
-      '<figure><img$1src="$2"$3></figure>'
+      (match, before, src, after) => {
+        if (src.startsWith('https://www.zhihu.com/equation?tex=')) return match
+        return `<figure><img${before}src="${src}"${after}></figure>`
+      }
     )
 
-    // 3. 代码块格式
+    // 4. 代码块格式
     result = result.replace(
       /<pre><code class="language-(\w+)">/gi,
       '<pre lang="$1"><code>'
     )
 
-    // 4. 移除微信样式属性 (但保留知乎的 data-draft-* 属性)
+    // 5. 移除微信样式属性 (但保留知乎的 data-draft-* 属性)
     result = result.replace(/\s*data-(?!draft)[a-z-]+="[^"]*"/gi, '')
     result = result.replace(/\s*style="[^"]*"/gi, '')
 
     return result
+  }
+
+  private transformLatex(content: string): string {
+    return content
+      .split(/(<pre[\s\S]*?<\/pre>)/gi)
+      .map((chunk) => {
+        if (/^<pre/i.test(chunk)) return chunk
+
+        return chunk
+          .replace(/\$\$([\s\S]+?)\$\$/g, (_match, latex) =>
+            this.zhihuEquationImage(latex, '2')
+          )
+          .replace(/\$([^$\n]+?)\$/g, (_match, latex) =>
+            this.zhihuEquationImage(latex, '1')
+          )
+      })
+      .join('')
+  }
+
+  private zhihuEquationImage(latex: string, eeimg: '1' | '2'): string {
+    const formula = latex.trim()
+    const encoded = encodeURIComponent(formula)
+    const alt = formula
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+
+    return `<img src="https://www.zhihu.com/equation?tex=${encoded}" alt="${alt}" class="ee_img tr_noresize" eeimg="${eeimg}">`
   }
 
   /**


### PR DESCRIPTION
Fixes #175.

## Summary
- convert inline and block LaTeX delimiters into Zhihu equation image tags during Zhihu content transformation
- keep equation images inline instead of wrapping them in normal image figures
- skip LaTeX replacement inside pre/code blocks

## Validation
- npm exec --yes --package=pnpm@10.17.0 -- pnpm --filter @wechatsync/core exec vitest run src/adapters/platforms/__tests__/zhihu.test.ts
- npm exec --yes --package=pnpm@10.17.0 -- pnpm --filter @wechatsync/core run typecheck
- git diff --check