### PR TITLE
fix(core): 修复微信公众号、掘金草稿封面未绑定的问题

### DIFF
--- a/packages/core/src/adapters/platforms/juejin.ts
+++ b/packages/core/src/adapters/platforms/juejin.ts
@@ -222,6 +222,19 @@ export class JuejinAdapter extends CodeAdapter {
         }
       )
 
+      // 4. 上传封面图(如有),拿 URL 填入草稿
+      let coverImage = ''
+      if (article.cover) {
+        try {
+          logger.info('Uploading cover image...')
+          const coverRes = await this.uploadImageByUrl(article.cover)
+          coverImage = coverRes.url
+          logger.debug('Cover uploaded:', coverImage)
+        } catch (err) {
+          logger.warn('Cover upload failed, skipping cover:', (err as Error).message)
+        }
+      }
+
       // 6. 创建草稿 (参数来自 DSL juejin.yaml + juejin.transform.ts prepareBody)
       const createResponse = await this.runtime.fetch(
         'https://api.juejin.cn/content_api/v1/article_draft/create',
@@ -235,7 +248,7 @@ export class JuejinAdapter extends CodeAdapter {
           body: JSON.stringify({
             brief_content: '',
             category_id: '0',
-            cover_image: '',
+            cover_image: coverImage,
             edit_type: 10,
             html_content: 'deprecated',
             link_url: '',

--- a/packages/core/src/adapters/platforms/weixin.ts
+++ b/packages/core/src/adapters/platforms/weixin.ts
@@ -164,6 +164,22 @@ export class WeixinAdapter extends CodeAdapter {
         content = this.processContent(content)
       }
 
+      // 上传封面图(如有),拿 fileid + cdn_url 用于绑定草稿封面
+      let coverFileId = ''
+      let coverCdnUrl = ''
+      if (article.cover) {
+        try {
+          logger.info('Uploading cover image...')
+          const coverRes = await this.uploadImageByUrl(article.cover)
+          coverCdnUrl = coverRes.url
+          coverFileId = String(coverRes.attrs?.fileid ?? '')
+          logger.debug('Cover uploaded:', { coverFileId, coverCdnUrl })
+        } catch (err) {
+          // 封面上传失败不阻断正文发布,记录警告后继续
+          logger.warn('Cover upload failed, skipping cover:', (err as Error).message)
+        }
+      }
+
       const formData = new URLSearchParams({
         token: this.weixinMeta!.token,
         lang: 'zh_CN',
@@ -182,17 +198,17 @@ export class WeixinAdapter extends CodeAdapter {
         title0: article.title,
         author0: '',
         writerid0: '0',
-        fileid0: '',
+        fileid0: coverFileId,
         digest0: '',
         auto_gen_digest0: '1',
         content0: content,
         sourceurl0: '',
         need_open_comment0: '1',
         only_fans_can_comment0: '0',
-        cdn_url0: '',
+        cdn_url0: coverCdnUrl,
         cdn_235_1_url0: '',
         cdn_1_1_url0: '',
-        cdn_url_back0: '',
+        cdn_url_back0: coverCdnUrl,
         crop_list0: '',
         music_id0: '',
         video_id0: '',
@@ -316,6 +332,8 @@ export class WeixinAdapter extends CodeAdapter {
 
     return {
       url: res.cdn_url,
+      // 保留 fileid(res.content),供封面绑定使用
+      attrs: res.content ? { fileid: res.content } : undefined,
     }
   }
 


### PR DESCRIPTION
## 问题

通过 CLI / MCP 同步文章时，传入的 \`cover\`（封面图）没有生效，草稿箱里的文章始终没有封面。

定位发现多个适配器完全忽略了 \`article.cover\`，封面相关字段硬编码为空：

| 适配器 | 问题字段 | 原因 |
|--------|---------|------|
| \`weixin.ts\` | \`fileid0\` / \`cdn_url0\` / \`cdn_url_back0\` 始终为空 | 完全忽略 \`article.cover\`；\`uploadImageByUrl\` 丢弃了响应里的 \`content\`（fileid） |
| \`juejin.ts\` | \`cover_image\` 硬编码为空 | 声明了 \`cover\` 能力，但 \`publish\` 没读取 \`article.cover\` |

## 修复

采用统一思路：\`publish\` 中若 \`article.cover\` 存在，先上传到平台图床拿 URL/fileid，填入对应字段；上传失败不阻断正文发布，记录 \`logger.warn\` 后继续。

**\`packages/core/src/adapters/platforms/weixin.ts\`（+21 / -3）：**
1. \`uploadImageByUrl\` 返回值通过 \`attrs.fileid\` 带出 \`res.content\`（原先丢弃）
2. \`publish\` 上传封面 → 填 \`fileid0\` / \`cdn_url0\` / \`cdn_url_back0\`

**\`packages/core/src/adapters/platforms/juejin.ts\`（+14 / -1）：**
1. \`publish\` 上传封面（复用现有 ImageX \`uploadImageByUrl\`）→ 填 \`cover_image\`

\`ImageUploadResult.attrs\` 字段本就存在，无需改动类型定义。\`sync-service.ts\` 也早已把 \`article.cover\` 透传到 \`publish\`，链路完整。

## 验证

- \`pnpm --filter @wechatsync/core typecheck\` 通过（strict 模式零错误）
- 本地构建扩展 \`pnpm --filter @wechatsync/extension build\` 通过
- **微信实测**：CLI \`wechatsync sync article.html -p weixin --cover cover.png\` 同步后，草稿箱文章封面正常显示（修复前无封面）
- **掘金实测**：通过本地修复版扩展同步，草稿生成成功（cover_image 填入图床 URL）；代码路径与微信一致，typecheck 通过

## 背景

- 微信草稿接口（\`operate_appmsg?sub=create\`）封面通过 \`fileid0\` + \`cdn_url0\` + \`cdn_url_back0\` 绑定，fileid 来自 \`filetransfer?action=upload_material\` 响应的 \`content\` 字段
- 掘金草稿接口（\`article_draft/create\`）封面字段为 \`cover_image\`，填图床 URL

## 说明

本 PR 只覆盖微信与掘金两个适配器。知乎适配器也存在「声明了 \`cover\` 能力但 \`publish\` 未处理」的情况，但其草稿接口的封面字段未公开、需抓包确认，留作后续单独 PR。