### PR TITLE
feat(extension): 添加 dev.to api key 发布

### DIFF
--- a/packages/extension/src/adapters/api-key/devto.ts
+++ b/packages/extension/src/adapters/api-key/devto.ts
@@ -1,0 +1,100 @@
+/**
+ * dev.to API Key 适配器
+ * 使用 Forem API 创建 dev.to 草稿
+ */
+interface DevtoCredentials {
+  apiKey: string
+}
+
+interface DevtoArticle {
+  title: string
+  content?: string
+  markdown?: string
+  cover?: string
+  tags?: string[]
+}
+
+const API_BASE_URL = 'https://dev.to'
+const API_ACCEPT = 'application/vnd.forem.api-v1+json'
+
+/**
+ * 解析 Forem API 错误响应
+ */
+async function parseError(response: Response): Promise<string> {
+  try {
+    const data = await response.json() as { error?: string; message?: string }
+    return data.error || data.message || `HTTP ${response.status}`
+  } catch {
+    return `HTTP ${response.status}`
+  }
+}
+
+/**
+ * 校验 API Key 是否可用
+ */
+export async function testConnection(credentials: DevtoCredentials): Promise<{ success: boolean; error?: string }> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/users/me`, {
+      headers: {
+        Accept: API_ACCEPT,
+        'api-key': credentials.apiKey,
+      },
+    })
+
+    if (!response.ok) {
+      return { success: false, error: await parseError(response) }
+    }
+
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: (error as Error).message }
+  }
+}
+
+/**
+ * 创建文章草稿
+ */
+export async function publish(
+  credentials: DevtoCredentials,
+  article: DevtoArticle,
+  options?: { draftOnly?: boolean }
+): Promise<{ success: boolean; postId?: string; postUrl?: string; message?: string; error?: string }> {
+  try {
+    const body = {
+      article: {
+        title: article.title,
+        body_markdown: article.markdown || article.content || '',
+        // 默认保存为草稿，避免误发布
+        published: !(options?.draftOnly ?? true),
+        tags: article.tags || [],
+        main_image: article.cover || undefined,
+      },
+    }
+
+    const response = await fetch(`${API_BASE_URL}/api/articles`, {
+      method: 'POST',
+      headers: {
+        Accept: API_ACCEPT,
+        'Content-Type': 'application/json',
+        'api-key': credentials.apiKey,
+      },
+      body: JSON.stringify(body),
+    })
+
+    if (!response.ok) {
+      return { success: false, error: await parseError(response) }
+    }
+
+    const data = await response.json() as { id?: number; url?: string }
+    // Forem 返回的草稿公开链接不可访问，草稿场景跳转到编辑页
+    const postUrl = options?.draftOnly && data.url ? `${data.url}/edit` : data.url
+
+    return {
+      success: true,
+      postId: data.id ? String(data.id) : undefined,
+      postUrl,
+    }
+  } catch (error) {
+    return { success: false, error: (error as Error).message }
+  }
+}

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -11,6 +11,7 @@ import {
 } from '../adapters'
 import * as wordpressAdapter from '../adapters/cms/wordpress'
 import * as metaweblogAdapter from '../adapters/cms/metaweblog'
+import * as devtoAdapter from '../adapters/api-key/devto'
 import { startMcpClient, stopMcpClient, getMcpStatus, mcpClient } from '../mcp/client'
 import { createLogger } from '../lib/logger'
 import {
@@ -33,6 +34,10 @@ const logger = createLogger('Background')
 
 // CMS 类型
 type CMSType = 'wordpress' | 'typecho' | 'metaweblog'
+// 配置账号类型：传统 CMS 站点与 API Key 授权平台共用本地账号存储
+type ConfigAccountKind = 'cms' | 'apiKey'
+// API Key 平台标识
+type ApiKeyProvider = 'devto'
 
 // 同步状态类型
 interface ActiveSyncState {
@@ -127,7 +132,7 @@ type MessageAction =
   | { type: 'CHECK_AUTH'; payload: { platformId: string } }
   | { type: 'SYNC_ARTICLE'; payload: { article: any; platforms: string[]; allSelectedPlatforms?: string[]; skipHistory?: boolean; source?: string; syncId?: string } }
   | { type: 'OPEN_SYNC_PAGE'; path?: string }
-  | { type: 'TEST_CMS_CONNECTION'; payload: { type: CMSType; url: string; username: string; password: string } }
+  | { type: 'TEST_CMS_CONNECTION'; payload: { kind?: ConfigAccountKind; type?: CMSType; provider?: ApiKeyProvider; url?: string; username?: string; password: string } }
   | { type: 'SYNC_TO_CMS'; payload: { accountId: string; article: any } }
   | { type: 'MCP_ENABLE' }
   | { type: 'MCP_DISABLE' }
@@ -179,18 +184,10 @@ async function handleMessage(message: MessageAction, sender?: chrome.runtime.Mes
       // 同时加载 CMS 账户
       const cmsStorage = await chrome.storage.local.get('cmsAccounts')
       const cmsAccounts = cmsStorage.cmsAccounts || []
+      // 配置账号包含 CMS 与 API Key 平台，统一转换为同步平台展示
       const cmsPlatforms = cmsAccounts
         .filter((a: any) => a.isConnected)
-        .map((a: any) => ({
-          id: a.id,
-          name: a.name,
-          icon: getCmsIcon(a.type),
-          homepage: a.url,
-          isAuthenticated: true,
-          username: a.username,
-          sourceType: 'cms' as const,
-          cmsType: a.type,
-        }))
+        .map(toConfiguredPlatform)
 
       const allPlatforms = [...dslWithType, ...cmsPlatforms]
       // 缓存完整平台列表，供 popup 启动时立即渲染
@@ -369,21 +366,8 @@ async function handleMessage(message: MessageAction, sender?: chrome.runtime.Mes
             payload: { platform: accountId, platformName: account.name, stage: 'saving' },
           })
 
-          const credentials = { url: account.url, username: account.username, password }
-          let result
-          switch (account.type) {
-            case 'wordpress':
-              result = await wordpressAdapter.publish(credentials, article, { draftOnly: true })
-              break
-            case 'typecho':
-              result = await metaweblogAdapter.publishToTypecho(credentials, article, { draftOnly: true })
-              break
-            case 'metaweblog':
-              result = await metaweblogAdapter.publish(credentials, article, { draftOnly: true })
-              break
-            default:
-              result = { success: false, error: '不支持的 CMS 类型' }
-          }
+          // 配置账号可能是 CMS 或 API Key 平台，统一交给分发函数处理
+          const result = await publishConfiguredAccount(account, password, article)
 
           const cmsResult = {
             platform: accountId,
@@ -482,29 +466,34 @@ async function handleMessage(message: MessageAction, sender?: chrome.runtime.Mes
     }
 
     case 'TEST_CMS_CONNECTION': {
-      const { type, url, username, password } = message.payload
-      const credentials = { url, username, password }
+      const { kind = 'cms', type, provider, url, username, password } = message.payload
+      const credentials = { url: url || '', username: username || '', password }
 
       try {
         let result
-        switch (type) {
-          case 'wordpress':
-            result = await wordpressAdapter.testConnection(credentials)
-            break
-          case 'typecho':
-            result = await metaweblogAdapter.testTypechoConnection(credentials)
-            break
-          case 'metaweblog':
-            result = await metaweblogAdapter.testConnection(credentials)
-            break
-          default:
-            return { success: false, error: '不支持的 CMS 类型' }
+        // API Key 平台没有站点地址和用户名，按 provider 选择专用校验逻辑
+        if (kind === 'apiKey' && provider === 'devto') {
+          result = await devtoAdapter.testConnection({ apiKey: password })
+        } else {
+          switch (type) {
+            case 'wordpress':
+              result = await wordpressAdapter.testConnection(credentials)
+              break
+            case 'typecho':
+              result = await metaweblogAdapter.testTypechoConnection(credentials)
+              break
+            case 'metaweblog':
+              result = await metaweblogAdapter.testConnection(credentials)
+              break
+            default:
+              return { success: false, error: '不支持的配置账号类型' }
+          }
         }
-        // 追踪 CMS 测试连接
-        trackCmsManagement('test', type, result.success).catch(() => {})
+        // 追踪配置账号测试连接，兼容原 CMS 埋点字段
+        trackCmsManagement('test', provider || type || kind, result.success).catch(() => {})
         return result
       } catch (error) {
-        trackCmsManagement('test', type, false).catch(() => {})
+        trackCmsManagement('test', provider || type || kind, false).catch(() => {})
         return { success: false, error: (error as Error).message }
       }
     }
@@ -527,29 +516,11 @@ async function handleMessage(message: MessageAction, sender?: chrome.runtime.Mes
           return { success: false, error: '密码未找到，请重新添加账户' }
         }
 
-        const credentials = {
-          url: account.url,
-          username: account.username,
-          password,
-        }
-
-        let result
-        switch (account.type) {
-          case 'wordpress':
-            result = await wordpressAdapter.publish(credentials, article, { draftOnly: true })
-            break
-          case 'typecho':
-            result = await metaweblogAdapter.publishToTypecho(credentials, article, { draftOnly: true })
-            break
-          case 'metaweblog':
-            result = await metaweblogAdapter.publish(credentials, article, { draftOnly: true })
-            break
-          default:
-            return { success: false, error: '不支持的 CMS 类型' }
-        }
+        // 配置账号可能是 CMS 或 API Key 平台，统一交给分发函数处理
+        const result = await publishConfiguredAccount(account, password, article)
 
         // 追踪 CMS 同步结果（含错误类型）
-        trackCmsSync('popup', account.type, result.success).catch(() => {})
+        trackCmsSync('popup', account.provider || account.type, result.success).catch(() => {})
         if (result.success) {
           // 追踪 CMS 用户里程碑
           trackMilestone('cms_user').catch(() => {})
@@ -557,6 +528,7 @@ async function handleMessage(message: MessageAction, sender?: chrome.runtime.Mes
           // 额外追踪错误类型用于问题分析
           trackFeatureUse('cms_sync_error', {
             cms_type: account.type,
+            provider: account.provider,
             error_type: inferErrorType(result.error),
           }).catch(() => {})
         }
@@ -831,21 +803,8 @@ async function handleMessage(message: MessageAction, sender?: chrome.runtime.Mes
             platform: accountId, platformName: account.name, stage: 'saving',
           })
 
-          const credentials = { url: account.url, username: account.username, password }
-          let result
-          switch (account.type) {
-            case 'wordpress':
-              result = await wordpressAdapter.publish(credentials, article, { draftOnly: true })
-              break
-            case 'typecho':
-              result = await metaweblogAdapter.publishToTypecho(credentials, article, { draftOnly: true })
-              break
-            case 'metaweblog':
-              result = await metaweblogAdapter.publish(credentials, article, { draftOnly: true })
-              break
-            default:
-              result = { success: false, error: '不支持的 CMS 类型' }
-          }
+          // 配置账号可能是 CMS 或 API Key 平台，统一交给分发函数处理
+          const result = await publishConfiguredAccount(account, password, article)
 
           const cmsResult = {
             platform: accountId,
@@ -1014,18 +973,10 @@ async function handleMessage(message: MessageAction, sender?: chrome.runtime.Mes
 
       const cmsStorage = await chrome.storage.local.get('cmsAccounts')
       const cmsAccounts = cmsStorage.cmsAccounts || []
+      // 编辑器打开时也需要带上已连接的配置账号
       const cmsPlatforms = cmsAccounts
         .filter((a: any) => a.isConnected)
-        .map((a: any) => ({
-          id: a.id,
-          name: a.name,
-          icon: getCmsIcon(a.type),
-          homepage: a.url,
-          isAuthenticated: true,
-          username: a.username,
-          sourceType: 'cms' as const,
-          cmsType: a.type,
-        }))
+        .map(toConfiguredPlatform)
 
       chrome.tabs.sendMessage(tabId, {
         type: 'OPEN_EDITOR',
@@ -1049,6 +1000,70 @@ function createContextMenu() {
     title: '同步助手 - 提取并编辑文章',
     contexts: ['page', 'selection'],
   })
+}
+
+/**
+ * 获取配置账号图标
+ * API Key 平台按 provider 返回图标，传统 CMS 继续复用 CMS 图标逻辑
+ */
+function getConfiguredAccountIcon(account: { kind?: ConfigAccountKind; type?: string; provider?: string }): string {
+  if (account.kind === 'apiKey' && account.provider === 'devto') {
+    return 'https://dev.to/favicon.ico'
+  }
+
+  return getCmsIcon(account.type || '')
+}
+
+/**
+ * 获取配置账号主页
+ * API Key 平台没有用户填写的站点地址，使用平台官网作为主页
+ */
+function getConfiguredAccountHomepage(account: { kind?: ConfigAccountKind; url?: string; provider?: string }): string {
+  if (account.kind === 'apiKey' && account.provider === 'devto') {
+    return 'https://dev.to'
+  }
+
+  return account.url || ''
+}
+
+/**
+ * 将本地配置账号转换为同步平台信息
+ * 注意：sourceType 保持为 cms，兼容现有同步选择和历史记录通道
+ */
+function toConfiguredPlatform(account: any) {
+  return {
+    id: account.id,
+    name: account.name,
+    icon: getConfiguredAccountIcon(account),
+    homepage: getConfiguredAccountHomepage(account),
+    isAuthenticated: true,
+    username: account.username,
+    sourceType: 'cms' as const,
+    cmsType: account.kind === 'apiKey' ? undefined : account.type,
+    provider: account.provider,
+  }
+}
+
+/**
+ * 发布到配置账号
+ * 传统 CMS 走原有适配器，API Key 平台按 provider 分发到专用适配器
+ */
+async function publishConfiguredAccount(account: any, password: string, article: any) {
+  if (account.kind === 'apiKey' && account.provider === 'devto') {
+    return await devtoAdapter.publish({ apiKey: password }, article, { draftOnly: true })
+  }
+
+  const credentials = { url: account.url, username: account.username, password }
+  switch (account.type) {
+    case 'wordpress':
+      return await wordpressAdapter.publish(credentials, article, { draftOnly: true })
+    case 'typecho':
+      return await metaweblogAdapter.publishToTypecho(credentials, article, { draftOnly: true })
+    case 'metaweblog':
+      return await metaweblogAdapter.publish(credentials, article, { draftOnly: true })
+    default:
+      return { success: false, error: '不支持的配置账号类型' }
+  }
 }
 
 // CMS 图标
@@ -1083,18 +1098,10 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
       // 获取 CMS 账户
       const cmsStorage = await chrome.storage.local.get('cmsAccounts')
       const cmsAccounts = cmsStorage.cmsAccounts || []
+      // 右键菜单打开编辑器时同样合并已连接的配置账号
       const cmsPlatforms = cmsAccounts
         .filter((a: any) => a.isConnected)
-        .map((a: any) => ({
-          id: a.id,
-          name: a.name,
-          icon: getCmsIcon(a.type),
-          homepage: a.url,
-          isAuthenticated: true,
-          username: a.username,
-          sourceType: 'cms' as const,
-          cmsType: a.type,
-        }))
+        .map(toConfiguredPlatform)
 
       // 合并所有平台
       const allPlatforms = [...dslWithType, ...cmsPlatforms]

--- a/packages/extension/src/background/sync-service.ts
+++ b/packages/extension/src/background/sync-service.ts
@@ -12,6 +12,7 @@ import {
 } from '../adapters'
 import * as wordpressAdapter from '../adapters/cms/wordpress'
 import * as metaweblogAdapter from '../adapters/cms/metaweblog'
+import * as devtoAdapter from '../adapters/api-key/devto'
 import { createLogger } from '../lib/logger'
 
 const logger = createLogger('SyncService')
@@ -375,18 +376,23 @@ export async function performSync(
       const credentials = { url: account.url, username: account.username, password }
       let result
 
-      switch (account.type) {
-        case 'wordpress':
-          result = await wordpressAdapter.publish(credentials, normalizedArticle, { draftOnly: true })
-          break
-        case 'typecho':
-          result = await metaweblogAdapter.publishToTypecho(credentials, normalizedArticle, { draftOnly: true })
-          break
-        case 'metaweblog':
-          result = await metaweblogAdapter.publish(credentials, normalizedArticle, { draftOnly: true })
-          break
-        default:
-          result = { success: false, error: '不支持的 CMS 类型' }
+      // MCP/CLI 同步复用配置账号存储，API Key 平台按 provider 分发
+      if (account.kind === 'apiKey' && account.provider === 'devto') {
+        result = await devtoAdapter.publish({ apiKey: password }, normalizedArticle, { draftOnly: true })
+      } else {
+        switch (account.type) {
+          case 'wordpress':
+            result = await wordpressAdapter.publish(credentials, normalizedArticle, { draftOnly: true })
+            break
+          case 'typecho':
+            result = await metaweblogAdapter.publishToTypecho(credentials, normalizedArticle, { draftOnly: true })
+            break
+          case 'metaweblog':
+            result = await metaweblogAdapter.publish(credentials, normalizedArticle, { draftOnly: true })
+            break
+          default:
+            result = { success: false, error: '不支持的配置账号类型' }
+        }
       }
 
       const cmsResult: SyncResult = {

--- a/packages/extension/src/mcp/client.ts
+++ b/packages/extension/src/mcp/client.ts
@@ -12,6 +12,9 @@ import { performSync } from '../background/sync-service'
 
 const logger = createLogger('MCPClient')
 
+// MCP 平台列表需要同时返回内置平台与本地配置账号
+type ConfigAccountKind = 'cms' | 'apiKey'
+
 // 消息类型
 interface RequestMessage {
   id: string
@@ -37,6 +40,39 @@ interface PendingUpload {
   platform: string
   createdAt: number
   timeoutId: ReturnType<typeof setTimeout>
+}
+
+/**
+ * 获取配置账号图标
+ * 与 background 中的平台展示保持一致，供 CLI/MCP 平台列表使用
+ */
+function getConfiguredAccountIcon(account: { kind?: ConfigAccountKind; type?: string; provider?: string }): string {
+  if (account.kind === 'apiKey' && account.provider === 'devto') {
+    return 'https://dev.to/favicon.ico'
+  }
+
+  switch (account.type) {
+    case 'wordpress':
+      return 'https://s.w.org/style/images/about/WordPress-logotype-simplified.png'
+    case 'typecho':
+      return chrome.runtime.getURL('assets/typecho.ico')
+    case 'metaweblog':
+      return 'https://www.cnblogs.com/favicon.ico'
+    default:
+      return chrome.runtime.getURL('assets/icon-48.png')
+  }
+}
+
+/**
+ * 获取配置账号主页
+ * API Key 平台没有自定义站点地址，返回平台固定主页
+ */
+function getConfiguredAccountHomepage(account: { kind?: ConfigAccountKind; url?: string; provider?: string }): string {
+  if (account.kind === 'apiKey' && account.provider === 'devto') {
+    return 'https://dev.to'
+  }
+
+  return account.url || ''
 }
 
 const DEFAULT_SERVER_URL = 'ws://localhost:9527'
@@ -313,7 +349,25 @@ class McpClient {
     switch (method) {
       case 'listPlatforms': {
         const forceRefresh = (params?.forceRefresh as boolean) ?? false
-        return await checkAllPlatformsAuth(forceRefresh)
+        const platforms = await checkAllPlatformsAuth(forceRefresh)
+        // CLI 的 platforms --auth 也应展示已连接的配置账号
+        const cmsStorage = await chrome.storage.local.get('cmsAccounts')
+        const cmsAccounts = cmsStorage.cmsAccounts || []
+        const configuredPlatforms = cmsAccounts
+          .filter((a: any) => a.isConnected)
+          .map((a: any) => ({
+            id: a.id,
+            name: a.name,
+            icon: getConfiguredAccountIcon(a),
+            homepage: getConfiguredAccountHomepage(a),
+            isAuthenticated: true,
+            username: a.username,
+            sourceType: 'cms',
+            cmsType: a.kind === 'apiKey' ? undefined : a.type,
+            provider: a.provider,
+          }))
+
+        return [...platforms, ...configuredPlatforms]
       }
 
       case 'checkAuth': {

--- a/packages/extension/src/popup/pages/AddCMS.tsx
+++ b/packages/extension/src/popup/pages/AddCMS.tsx
@@ -2,11 +2,19 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ArrowLeft, Globe, Loader2 } from 'lucide-react'
 import { Button } from '../components/ui/Button'
-import { useCMSStore, type CMSType } from '../stores/cms'
+import { useCMSStore, type ApiKeyProvider, type CMSType } from '../stores/cms'
 import { trackPageView, trackPlatformExpansion } from '../../lib/analytics'
 
 interface CMSOption {
   id: CMSType
+  name: string
+  description: string
+  icon: string
+}
+
+// API Key 平台不是 CMS，单独建模以避免混入 CMS 类型
+interface ApiKeyOption {
+  id: ApiKeyProvider
   name: string
   description: string
   icon: string
@@ -33,6 +41,16 @@ const cmsOptions: CMSOption[] = [
   },
 ]
 
+// 使用 API Key 授权的平台列表，首批只接入 dev.to
+const apiKeyOptions: ApiKeyOption[] = [
+  {
+    id: 'devto',
+    name: 'dev.to',
+    description: '使用 Forem API Key 发布草稿',
+    icon: 'https://dev.to/favicon.ico',
+  },
+]
+
 // 第三方平台类型（从 adapter registry 获取）
 interface ThirdPartyPlatform {
   id: string
@@ -46,6 +64,8 @@ export function AddCMSPage() {
   const { addAccount } = useCMSStore()
   const [step, setStep] = useState<'select' | 'config'>('select')
   const [selectedCMS, setSelectedCMS] = useState<CMSType | null>(null)
+  // API Key 平台与 CMS 互斥选择，共用后续配置表单
+  const [selectedApiKeyProvider, setSelectedApiKeyProvider] = useState<ApiKeyProvider | null>(null)
   const [config, setConfig] = useState({
     url: '',
     username: '',
@@ -85,6 +105,15 @@ export function AddCMSPage() {
 
   const handleSelectCMS = (cmsId: CMSType) => {
     setSelectedCMS(cmsId)
+    // 切换到 CMS 时清空 API Key 平台选择，避免提交混合配置
+    setSelectedApiKeyProvider(null)
+    setStep('config')
+  }
+
+  const handleSelectApiKeyProvider = (provider: ApiKeyProvider) => {
+    // 切换到 API Key 平台时清空 CMS 类型，保持语义独立
+    setSelectedCMS(null)
+    setSelectedApiKeyProvider(provider)
     setStep('config')
   }
 
@@ -95,7 +124,10 @@ export function AddCMSPage() {
 
     try {
       const result = await addAccount({
-        type: selectedCMS!,
+        // CMS 与 API Key 平台共用本地账号存储，通过 kind/provider 区分
+        kind: selectedApiKeyProvider ? 'apiKey' : 'cms',
+        type: selectedCMS || undefined,
+        provider: selectedApiKeyProvider || undefined,
         name: config.name,
         url: config.url,
         username: config.username,
@@ -106,7 +138,7 @@ export function AddCMSPage() {
         // 追踪平台扩展（获取当前 CMS 账户数量）
         chrome.storage.local.get('cmsAccounts').then((storage) => {
           const total = (storage.cmsAccounts || []).length
-          trackPlatformExpansion(`cms_${selectedCMS}`, total).catch(() => {})
+          trackPlatformExpansion(`cms_${selectedCMS || selectedApiKeyProvider}`, total).catch(() => {})
         })
         navigate('/')
       } else {
@@ -118,6 +150,12 @@ export function AddCMSPage() {
 
     setLoading(false)
   }
+
+  const selectedOption = selectedCMS
+    ? cmsOptions.find(c => c.id === selectedCMS)
+    : apiKeyOptions.find(c => c.id === selectedApiKeyProvider)
+  // API Key 平台只需要名称和密钥，不需要站点地址与用户名
+  const isApiKeyPlatform = !!selectedApiKeyProvider
 
   return (
     <div className="p-4">
@@ -165,6 +203,39 @@ export function AddCMSPage() {
             </div>
           </div>
 
+          {/* API Key 平台 */}
+          <div>
+            <h2 className="text-lg font-semibold mb-1">API Key 平台</h2>
+            <p className="text-xs text-muted-foreground mb-3">
+              添加使用 API Key 授权的平台
+            </p>
+
+            <div className="space-y-2">
+              {apiKeyOptions.map(platform => (
+                <button
+                  key={platform.id}
+                  onClick={() => handleSelectApiKeyProvider(platform.id)}
+                  className="w-full flex items-center gap-3 p-3 rounded-lg border hover:border-primary transition-colors text-left"
+                >
+                  <img
+                    src={platform.icon}
+                    alt={platform.name}
+                    className="w-8 h-8 rounded"
+                    onError={e => {
+                      (e.target as HTMLImageElement).src = '/assets/icon-48.png'
+                    }}
+                  />
+                  <div className="flex-1">
+                    <div className="font-medium text-sm">{platform.name}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {platform.description}
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+
           {/* 第三方平台 */}
           <div>
             <h2 className="text-lg font-semibold mb-1">第三方平台</h2>
@@ -204,13 +275,13 @@ export function AddCMSPage() {
         </div>
       )}
 
-      {step === 'config' && selectedCMS && (
+      {step === 'config' && selectedOption && (
         <>
           <h2 className="text-lg font-semibold mb-1">
-            配置 {cmsOptions.find(c => c.id === selectedCMS)?.name}
+            配置 {selectedOption.name}
           </h2>
           <p className="text-xs text-muted-foreground mb-4">
-            输入站点信息以连接
+            {isApiKeyPlatform ? '输入 API Key 以连接' : '输入站点信息以连接'}
           </p>
 
           <form onSubmit={handleSubmit} className="space-y-4">
@@ -226,7 +297,8 @@ export function AddCMSPage() {
               />
             </div>
 
-            <div>
+            {/* API Key 平台不需要站点地址 */}
+            {!isApiKeyPlatform && <div>
               <label className="block text-sm font-medium mb-1">站点地址</label>
               <div className="relative">
                 <Globe className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
@@ -239,9 +311,10 @@ export function AddCMSPage() {
                   required
                 />
               </div>
-            </div>
+            </div>}
 
-            <div>
+            {/* API Key 平台不需要用户名 */}
+            {!isApiKeyPlatform && <div>
               <label className="block text-sm font-medium mb-1">用户名</label>
               <input
                 type="text"
@@ -251,20 +324,22 @@ export function AddCMSPage() {
                 className="w-full px-3 py-2 rounded-md border bg-background text-sm"
                 required
               />
-            </div>
+            </div>}
 
             <div>
-              <label className="block text-sm font-medium mb-1">密码</label>
+              <label className="block text-sm font-medium mb-1">
+                {isApiKeyPlatform ? 'API Key' : '密码'}
+              </label>
               <input
                 type="password"
                 value={config.password}
                 onChange={e => setConfig({ ...config, password: e.target.value })}
-                placeholder="••••••••"
+                placeholder={isApiKeyPlatform ? 'dev.to API Key' : '••••••••'}
                 className="w-full px-3 py-2 rounded-md border bg-background text-sm"
                 required
               />
               <p className="text-xs text-muted-foreground mt-1">
-                密码仅存储在本地，不会上传到任何服务器
+                {isApiKeyPlatform ? 'API Key 仅存储在本地' : '密码仅存储在本地，不会上传到任何服务器'}
               </p>
             </div>
 

--- a/packages/extension/src/popup/stores/cms.ts
+++ b/packages/extension/src/popup/stores/cms.ts
@@ -4,24 +4,33 @@ import { createLogger } from '../../lib/logger'
 const logger = createLogger('CMSStore')
 
 export type CMSType = 'wordpress' | 'typecho' | 'metaweblog'
+// 配置账号类型：CMS 与 API Key 平台复用同一套本地管理入口
+export type ConfigAccountKind = 'cms' | 'apiKey'
+// API Key 平台标识，当前仅支持 dev.to
+export type ApiKeyProvider = 'devto'
 
 export interface CMSAccount {
   id: string
-  type: CMSType
+  // 旧账号没有 kind 字段，缺省按 CMS 处理
+  kind?: ConfigAccountKind
+  type?: CMSType
+  provider?: ApiKeyProvider
   name: string
-  url: string
-  username: string
+  url?: string
+  username?: string
   // 密码存储在 chrome.storage.local 中，不在状态里
   isConnected: boolean
   lastError?: string
 }
+
+type AddAccountInput = Omit<CMSAccount, 'id' | 'isConnected'> & { password: string }
 
 interface CMSState {
   accounts: CMSAccount[]
   loading: boolean
 
   loadAccounts: () => Promise<void>
-  addAccount: (account: Omit<CMSAccount, 'id' | 'isConnected'> & { password: string }) => Promise<{ success: boolean; error?: string }>
+  addAccount: (account: AddAccountInput) => Promise<{ success: boolean; error?: string }>
   removeAccount: (id: string) => Promise<void>
   testConnection: (id: string) => Promise<{ success: boolean; error?: string }>
 }
@@ -47,11 +56,17 @@ export const useCMSStore = create<CMSState>((set) => ({
       // 直接从 storage 读取，避免 Zustand state 未加载导致覆盖
       const storage = await chrome.storage.local.get('cmsAccounts')
       const accounts: CMSAccount[] = storage.cmsAccounts || []
-      const id = `cms_${Date.now()}`
+      // API Key 平台使用 provider 前缀，避免在 CLI 中显示为 cms_xxx
+      const id = accountData.kind === 'apiKey' && accountData.provider
+        ? `${accountData.provider}_${Date.now()}`
+        : `cms_${Date.now()}`
 
       const newAccount: CMSAccount = {
         id,
+        // 兼容旧 CMS 账号：未传 kind 时仍按 CMS 保存
+        kind: accountData.kind || 'cms',
         type: accountData.type,
+        provider: accountData.provider,
         name: accountData.name,
         url: accountData.url,
         username: accountData.username,
@@ -62,7 +77,10 @@ export const useCMSStore = create<CMSState>((set) => ({
       const testResult = await chrome.runtime.sendMessage({
         type: 'TEST_CMS_CONNECTION',
         payload: {
+          // 测试连接时带上 kind/provider，让 background 能分流到 API Key 适配器
+          kind: accountData.kind || 'cms',
           type: accountData.type,
+          provider: accountData.provider,
           url: accountData.url,
           username: accountData.username,
           password: accountData.password,
@@ -118,7 +136,10 @@ export const useCMSStore = create<CMSState>((set) => ({
       const result = await chrome.runtime.sendMessage({
         type: 'TEST_CMS_CONNECTION',
         payload: {
+          // 重新测试旧账号时缺省为 CMS，避免破坏已有配置
+          kind: account.kind || 'cms',
           type: account.type,
+          provider: account.provider,
           url: account.url,
           username: account.username,
           password,


### PR DESCRIPTION
- 新增 API Key 平台，dev.to 归类为 API Key。
- 复用现有配置账号存储，支持测试连接、草稿同步、CLI platforms --auth 展示。
- dev.to 草稿返回编辑页链接，避免公开草稿 URL 显示不存在。