### PR TITLE
fix(mcp): bound image uploads and expose bridge diagnostics

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -610,6 +610,13 @@ async function createBridge(): Promise<ExtensionBridge | null> {
         // PRIMARY 可达但 Extension 没连上
         console.log()
         console.log(chalk.red('连接超时: 已有实例正在运行但 Chrome Extension 未连接'))
+        const primaryStatus = bridge.getPrimaryStatus()
+        if (primaryStatus?.pid) {
+          const startedAt = primaryStatus.startedAt
+            ? new Date(primaryStatus.startedAt).toLocaleString()
+            : '未知'
+          console.log(chalk.gray(`PRIMARY 进程: PID ${primaryStatus.pid}，启动时间: ${startedAt}`))
+        }
         console.log(chalk.gray('请确保 Chrome 扩展已启用「同步桥接」并且 Token 正确'))
       }
     } else {

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -124,6 +124,7 @@ yarn build
 
 - `MCP_TOKEN`: 安全验证 Token（必需）
 - `SYNC_WS_PORT`: WebSocket 端口（默认 9527）
+- `WECHATSYNC_UPLOAD_TIMEOUT`: 单张图片上传超时，单位毫秒（默认 60000）
 - `SYNC_HTTP_PORT`: HTTP 端口（默认 9528，仅 SSE 模式）
 
 ## 开发

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "node --test test/*.test.mjs"
   },
   "keywords": [
     "wechatsync",

--- a/packages/mcp-server/src/ws-bridge.ts
+++ b/packages/mcp-server/src/ws-bridge.ts
@@ -12,6 +12,14 @@ import type { RequestMessage, ResponseMessage } from './types.js'
 // WebSocket 状态常量 (readyState: 1 = OPEN)
 const WS_OPEN = WebSocket.OPEN
 
+interface PrimaryStatus {
+  connected: boolean
+  pid?: number
+  startedAt?: number
+  uptimeMs?: number
+  error?: string
+}
+
 export class ExtensionBridge {
   private wss: any = null
   private httpServer: http.Server | null = null
@@ -23,7 +31,13 @@ export class ExtensionBridge {
     timeout: NodeJS.Timeout
   }>()
   private requestTimeout = 360000 // 6 minutes (图片多时需要更长时间)
+  private uploadRequestTimeout = this.readPositiveTimeout(
+    process.env.WECHATSYNC_UPLOAD_TIMEOUT,
+    60000
+  )
   private connectionResolvers: Array<() => void> = []
+  private readonly startedAt = Date.now()
+  private primaryStatus: PrimaryStatus | null = null
 
   // 安全验证 token（从环境变量读取，优先使用 WECHATSYNC_TOKEN）
   private token: string = process.env.WECHATSYNC_TOKEN || process.env.MCP_TOKEN || ''
@@ -130,7 +144,10 @@ export class ExtensionBridge {
           res.writeHead(200, { 'Content-Type': 'application/json' })
           res.end(JSON.stringify({
             connected: this.isConnected(),
-            mode: 'primary'
+            mode: 'primary',
+            pid: process.pid,
+            startedAt: this.startedAt,
+            uptimeMs: Date.now() - this.startedAt,
           }))
           return
         }
@@ -170,6 +187,16 @@ export class ExtensionBridge {
    * 停止服务器
    */
   stop(): void {
+    for (const pending of this.pendingRequests.values()) {
+      clearTimeout(pending.timeout)
+      pending.reject(new Error('Bridge stopped before the request completed'))
+    }
+    this.pendingRequests.clear()
+
+    if (this.client) {
+      this.client.close()
+      this.client = null
+    }
     if (this.wss) {
       this.wss.close()
       this.wss = null
@@ -188,6 +215,10 @@ export class ExtensionBridge {
    */
   getMode(): 'primary' | 'secondary' {
     return this.isServerMode ? 'primary' : 'secondary'
+  }
+
+  getPrimaryStatus(): PrimaryStatus | null {
+    return this.primaryStatus
   }
 
   /**
@@ -245,6 +276,7 @@ export class ExtensionBridge {
           }
 
           const health = await this.checkPrimaryHealth()
+          this.primaryStatus = health
           if (health.connected) {
             resolve()
             return
@@ -296,7 +328,7 @@ export class ExtensionBridge {
   /**
    * 检查 Primary 实例健康状态（Secondary 模式用）
    */
-  private async checkPrimaryHealth(): Promise<{ connected: boolean; error?: string }> {
+  private async checkPrimaryHealth(): Promise<PrimaryStatus> {
     return new Promise((resolve) => {
       const options = {
         hostname: 'localhost',
@@ -312,7 +344,12 @@ export class ExtensionBridge {
         res.on('end', () => {
           try {
             const status = JSON.parse(body)
-            resolve({ connected: status.connected })
+            resolve({
+              connected: status.connected,
+              pid: status.pid,
+              startedAt: status.startedAt,
+              uptimeMs: status.uptimeMs,
+            })
           } catch {
             resolve({ connected: false, error: 'Invalid response from primary' })
           }
@@ -368,6 +405,7 @@ export class ExtensionBridge {
 
       // 检查 PRIMARY 健康状态
       const health = await this.checkPrimaryHealth()
+      this.primaryStatus = health
       if (!health.connected) {
         if (health.error?.includes('not reachable')) {
           // PRIMARY 已退出，尝试接管
@@ -434,7 +472,7 @@ export class ExtensionBridge {
       const timeout = setTimeout(() => {
         this.pendingRequests.delete(id)
         reject(new Error(`Request timeout: ${method}`))
-      }, this.requestTimeout)
+      }, this.getRequestTimeout(method))
 
       this.pendingRequests.set(id, { resolve: resolve as (value: unknown) => void, reject, timeout })
 
@@ -483,7 +521,7 @@ export class ExtensionBridge {
         reject(new Error(`Failed to connect to primary MCP instance: ${error.message}${hint}`))
       })
 
-      req.setTimeout(this.requestTimeout, () => {
+      req.setTimeout(this.getRequestTimeout(method), () => {
         req.destroy()
         reject(new Error(`Request timeout: ${method}`))
       })
@@ -524,6 +562,17 @@ export class ExtensionBridge {
    */
   private generateId(): string {
     return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
+  }
+
+  private readPositiveTimeout(value: string | undefined, fallback: number): number {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+  }
+
+  private getRequestTimeout(method: string): number {
+    return method === 'uploadImage' || method === 'uploadImage:complete'
+      ? this.uploadRequestTimeout
+      : this.requestTimeout
   }
 
   // 分片上传配置

--- a/packages/mcp-server/test/ws-bridge.test.mjs
+++ b/packages/mcp-server/test/ws-bridge.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { WebSocket } from 'ws'
+import { ExtensionBridge } from '../dist/exports.js'
+
+const TEST_PORT = 19527
+
+function waitForOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once('open', resolve)
+    ws.once('error', reject)
+  })
+}
+
+test('status exposes primary diagnostics', async () => {
+  const bridge = new ExtensionBridge(TEST_PORT, { silent: true })
+  await bridge.start()
+
+  try {
+    const response = await fetch(`http://localhost:${TEST_PORT + 1}/status`)
+    const status = await response.json()
+
+    assert.equal(status.mode, 'primary')
+    assert.equal(status.connected, false)
+    assert.equal(status.pid, process.pid)
+    assert.equal(typeof status.startedAt, 'number')
+    assert.equal(typeof status.uptimeMs, 'number')
+  } finally {
+    bridge.stop()
+  }
+})
+
+test('image upload requests use the bounded upload timeout', async () => {
+  process.env.WECHATSYNC_UPLOAD_TIMEOUT = '50'
+  const bridge = new ExtensionBridge(TEST_PORT + 2, { silent: true })
+  await bridge.start()
+  const ws = new WebSocket(`ws://localhost:${TEST_PORT + 2}`)
+  await waitForOpen(ws)
+
+  try {
+    await assert.rejects(
+      bridge.request('uploadImage', { imageData: 'AA==', mimeType: 'image/png' }),
+      /Request timeout: uploadImage/
+    )
+  } finally {
+    bridge.stop()
+    delete process.env.WECHATSYNC_UPLOAD_TIMEOUT
+  }
+})
+
+test('stopping the bridge rejects pending requests', async () => {
+  const bridge = new ExtensionBridge(TEST_PORT + 4, { silent: true })
+  await bridge.start()
+  const ws = new WebSocket(`ws://localhost:${TEST_PORT + 4}`)
+  await waitForOpen(ws)
+
+  const pending = bridge.request('syncArticle', { article: { title: 'test' } })
+  bridge.stop()
+
+  await assert.rejects(pending, /Bridge stopped before the request completed/)
+})


### PR DESCRIPTION
## Summary

- bound `uploadImage` and `uploadImage:complete` requests to a dedicated 60-second timeout
- expose Primary bridge PID, start time, and uptime through `/status`
- show Primary process diagnostics when a Secondary CLI instance times out
- reject pending requests when the bridge stops
- document `WECHATSYNC_UPLOAD_TIMEOUT`

## Why

A platform adapter can leave `uploadImage(blob)` pending indefinitely. The CLI processes local images sequentially, so one stuck upload blocked the entire sync until the bridge-wide six-minute timeout.

Separately, when an old Primary process still owned ports 9527/9528 but the extension was disconnected, new CLI instances could only report a generic connection error. Exposing process diagnostics makes the stale owner identifiable without introducing unsafe automatic process termination.

Closes #208.
Partially addresses #207. A safe reset/takeover mechanism still needs an ownership or heartbeat design.

## Tests

- `corepack yarn workspace @wechatsync/mcp-server build`
- `corepack yarn workspace @wechatsync/cli build`
- `corepack yarn workspace @wechatsync/mcp-server test`

Added coverage for:

- Primary status diagnostics
- bounded image upload timeout
- rejection of pending requests during bridge shutdown

All 3 tests pass on Windows 11 / Node.js 24.14.0.

## Compatibility

- `syncArticle` keeps the existing six-minute timeout.
- Existing `/status` fields remain unchanged; new fields are additive.
- The default upload timeout can be overridden with `WECHATSYNC_UPLOAD_TIMEOUT`.
