### PR TITLE
feat(extension): add Bridge v2 and trusted Zhihu publication verification

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,11 @@
       "types": "./src/runtime/index.ts",
       "import": "./src/runtime/index.ts",
       "require": "./src/runtime/index.ts"
+    },
+    "./publication-inspection": {
+      "types": "./src/publication-inspection/index.ts",
+      "import": "./src/publication-inspection/index.ts",
+      "require": "./src/publication-inspection/index.ts"
     }
   },
   "scripts": {

--- a/packages/core/src/adapters/platforms/zhihu.ts
+++ b/packages/core/src/adapters/platforms/zhihu.ts
@@ -4,6 +4,11 @@
 import { CodeAdapter, type ImageUploadResult } from '../code-adapter'
 import type { Article, AuthResult, SyncResult, PlatformMeta } from '../../types'
 import type { PublishOptions } from '../types'
+import type {
+  PublicationInspectRequest,
+  PublicationObservation,
+} from '../../publication-inspection/types'
+import { inspectZhihuPublication } from '../../publication-inspection/zhihu'
 import { createLogger } from '../../lib/logger'
 import md5Lib from 'js-md5'
 
@@ -89,6 +94,15 @@ export class ZhihuAdapter extends CodeAdapter {
       logger.debug('checkAuth: not logged in -', error)
       return { isAuthenticated: false, error: (error as Error).message }
     }
+  }
+
+  async inspectPublication(
+    request: PublicationInspectRequest
+  ): Promise<PublicationObservation[]> {
+    return inspectZhihuPublication(request, {
+      checkAuth: () => this.checkAuth(),
+      fetch: (url, options) => this.runtime.fetch(url, options),
+    })
   }
 
   async publish(article: Article, options?: PublishOptions): Promise<SyncResult> {

--- a/packages/core/src/adapters/types.ts
+++ b/packages/core/src/adapters/types.ts
@@ -1,5 +1,9 @@
 import type { Article, AuthResult, SyncResult, PlatformMeta } from '../types'
 import type { RuntimeInterface } from '../runtime/interface'
+import type {
+  PublicationInspectRequest,
+  PublicationObservation,
+} from '../publication-inspection/types'
 
 /**
  * 输出格式类型
@@ -131,6 +135,15 @@ export interface PlatformAdapter {
 
   /** 发布文章 */
   publish(article: Article, options?: PublishOptions): Promise<SyncResult>
+
+  /**
+   * Read-only publication verification. Implementations must validate the
+   * requested external account and must not infer NOT_FOUND from a failed
+   * request or an unverified response shape.
+   */
+  inspectPublication?(
+    request: PublicationInspectRequest
+  ): Promise<PublicationObservation[]>
 
   /** 上传图片 (如果支持) */
   uploadImage?(file: Blob, filename?: string): Promise<string>

--- a/packages/core/src/publication-inspection/__fixtures__/url-samples.json
+++ b/packages/core/src/publication-inspection/__fixtures__/url-samples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "zhihu article draft",
+    "platform": "zhihu",
+    "href": "https://zhuanlan.zhihu.com/p/2000000000000000001/edit",
+    "expected": {
+      "surface": "DRAFT",
+      "postId": "2000000000000000001"
+    }
+  },
+  {
+    "name": "zhihu published article",
+    "platform": "zhihu",
+    "href": "https://zhuanlan.zhihu.com/p/2000000000000000001?utm_source=test",
+    "expected": {
+      "surface": "PUBLISHED",
+      "postId": "2000000000000000001",
+      "canonicalUrl": "https://zhuanlan.zhihu.com/p/2000000000000000001"
+    }
+  }
+]

--- a/packages/core/src/publication-inspection/__tests__/sanitize.test.ts
+++ b/packages/core/src/publication-inspection/__tests__/sanitize.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBoundaryUrl, sanitizeSyncResultForBoundary } from '../sanitize'
+
+describe('sanitizeBoundaryUrl', () => {
+  it('never exposes a WeChat URL', () => {
+    expect(
+      sanitizeBoundaryUrl(
+        'weixin',
+        'https://mp.weixin.qq.com/cgi-bin/appmsg?appmsgid=9001&token=secret',
+      ),
+    ).toBeUndefined()
+    expect(
+      sanitizeBoundaryUrl(
+        ' WEIXIN ',
+        'https://mp.weixin.qq.com/s?__biz=public&mid=9001',
+      ),
+    ).toBeUndefined()
+  })
+
+  it('removes sensitive query parameters and the complete fragment', () => {
+    expect(
+      sanitizeBoundaryUrl(
+        'zhihu',
+        'https://example.com/draft/42?mid=42&TOKEN=one&access_token=two' +
+          '&ticket=three&session_id=four&authKey=five' +
+          '&X-Amz-Signature=six&clientSecret=seven&safe=ok#token=fragment',
+      ),
+    ).toBe('https://example.com/draft/42?mid=42&safe=ok')
+  })
+
+  it('recognizes encoded, camelCase, and compact sensitive keys', () => {
+    expect(
+      sanitizeBoundaryUrl(
+        'sohu',
+        'https://example.com/article?access%5Ftoken=one&refreshToken=two' +
+          '&sessionid=three&apiKey=four&article_id=42',
+      ),
+    ).toBe('https://example.com/article?article_id=42')
+  })
+
+  it.each([
+    'javascript:alert(1)',
+    'data:text/plain,secret',
+    'https://user@example.com/article',
+    'https://user:password@example.com/article',
+    '/relative/article',
+  ])('rejects a non-http, credentialed, or relative URL: %s', (value) => {
+    expect(sanitizeBoundaryUrl('zhihu', value)).toBeUndefined()
+  })
+
+  it('allows both HTTP and HTTPS URLs with non-sensitive query parameters', () => {
+    expect(
+      sanitizeBoundaryUrl(
+        'sohu',
+        'http://mp.sohu.com/editor?id=42&accountId=7#draft',
+      ),
+    ).toBe('http://mp.sohu.com/editor?id=42&accountId=7')
+    expect(
+      sanitizeBoundaryUrl('zhihu', 'https://zhuanlan.zhihu.com/p/42/edit'),
+    ).toBe('https://zhuanlan.zhihu.com/p/42/edit')
+  })
+})
+
+describe('sanitizeSyncResultForBoundary', () => {
+  it('preserves postId while removing both WeChat URL aliases', () => {
+    const input = {
+      platform: 'weixin',
+      success: true,
+      postId: '900000001',
+      postUrl:
+        'https://mp.weixin.qq.com/cgi-bin/appmsg?appmsgid=900000001&token=secret',
+      url: 'https://mp.weixin.qq.com/s?__biz=public&mid=900000001',
+      draftOnly: true,
+      timestamp: 1,
+    }
+
+    expect(sanitizeSyncResultForBoundary(input)).toEqual({
+      platform: 'weixin',
+      success: true,
+      postId: '900000001',
+      draftOnly: true,
+      timestamp: 1,
+    })
+    expect(input.postUrl).toContain('token=secret')
+    expect(input.postId).toBe('900000001')
+  })
+
+  it('sanitizes both URL aliases without dropping other result fields', () => {
+    expect(
+      sanitizeSyncResultForBoundary({
+        platform: 'zhihu',
+        success: true,
+        postId: '42',
+        postUrl:
+          'https://zhuanlan.zhihu.com/p/42/edit?token=secret&source=sync#draft',
+        url: 'https://zhuanlan.zhihu.com/p/42?signature=secret&from=sync',
+        message: 'saved',
+      }),
+    ).toEqual({
+      platform: 'zhihu',
+      success: true,
+      postId: '42',
+      postUrl: 'https://zhuanlan.zhihu.com/p/42/edit?source=sync',
+      url: 'https://zhuanlan.zhihu.com/p/42?from=sync',
+      message: 'saved',
+    })
+  })
+
+  it('removes invalid and non-string URL fields', () => {
+    expect(
+      sanitizeSyncResultForBoundary({
+        platform: 'sohu',
+        success: false,
+        postId: 'draft-1',
+        postUrl: 'https://user@example.com/draft/1',
+        url: { href: 'https://example.com' },
+        error: 'failed',
+      }),
+    ).toEqual({
+      platform: 'sohu',
+      success: false,
+      postId: 'draft-1',
+      error: 'failed',
+    })
+  })
+})

--- a/packages/core/src/publication-inspection/__tests__/types.test.ts
+++ b/packages/core/src/publication-inspection/__tests__/types.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PublicationInspectRequestSchema,
+  PublicationObservationSchema,
+  SYNCER_BRIDGE_REQUEST_ID_MAX_LENGTH,
+  SyncerAccountV2Schema,
+} from '../types'
+
+describe('publication inspection contracts', () => {
+  it('accepts one stable account identity for a supported platform', () => {
+    expect(
+      SyncerAccountV2Schema.parse({
+        platform: 'sohu',
+        externalAccountId: 'account-1',
+        displayName: '示例账号',
+        capabilities: ['account_identity', 'publication_inspect'],
+      }),
+    ).toMatchObject({ externalAccountId: 'account-1' })
+  })
+
+  it('limits one inspection to at most 20 candidates', () => {
+    const result = PublicationInspectRequestSchema.safeParse({
+      requestId: 'request-1',
+      platform: 'zhihu',
+      externalAccountId: 'account-1',
+      draft: {
+        platformPostId: 'post-1',
+        draftedAt: '2026-07-21T12:00:00+08:00',
+      },
+      articleHint: { title: '示例文章' },
+      limit: 21,
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('normalizes request IDs before enforcing the 128-character limit', () => {
+    const requestId = 'r'.repeat(SYNCER_BRIDGE_REQUEST_ID_MAX_LENGTH)
+    const baseRequest = {
+      platform: 'zhihu',
+      externalAccountId: 'account-1',
+      draft: {
+        platformPostId: 'post-1',
+        draftedAt: '2026-07-21T12:00:00+08:00',
+      },
+      articleHint: { title: '示例文章' },
+      limit: 20,
+    }
+
+    expect(
+      PublicationInspectRequestSchema.parse({
+        ...baseRequest,
+        requestId: ` ${requestId} `,
+      }).requestId,
+    ).toBe(requestId)
+    expect(
+      PublicationInspectRequestSchema.safeParse({
+        ...baseRequest,
+        requestId: `${requestId}x`,
+      }).success,
+    ).toBe(false)
+  })
+
+  it('requires an explicit errorCode for adapter failures', () => {
+    const result = PublicationObservationSchema.safeParse({
+      observationKey: 'observation-1',
+      platform: 'toutiao',
+      externalAccountId: 'account-1',
+      outcome: 'PARSE_ERROR',
+      source: 'PUBLISHED_LIST',
+      observedAt: '2026-07-21T12:00:00+08:00',
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it.each(['ACCOUNT_MISMATCH', 'REVIEW_REQUIRED'])(
+    'requires an explicit errorCode for %s',
+    (outcome) => {
+      const result = PublicationObservationSchema.safeParse({
+        observationKey: 'observation-1',
+        platform: 'sohu',
+        externalAccountId: 'account-1',
+        outcome,
+        source: 'PLATFORM_DETAIL',
+        observedAt: '2026-07-21T12:00:00+08:00',
+      })
+
+      expect(result.success).toBe(false)
+    },
+  )
+
+  it.each(['PENDING_REVIEW', 'REJECTED', 'SCHEDULED'])(
+    'accepts the explicit platform lifecycle state %s',
+    (outcome) => {
+      const result = PublicationObservationSchema.safeParse({
+        observationKey: 'observation-1',
+        platform: 'sohu',
+        externalAccountId: 'account-1',
+        outcome,
+        source: 'PLATFORM_DETAIL',
+        platformPostId: 'post-1',
+        observedAt: '2026-07-21T12:00:00+08:00',
+      })
+
+      expect(result.success).toBe(true)
+    },
+  )
+
+  it('does not accept a published observation without a stable anchor', () => {
+    const result = PublicationObservationSchema.safeParse({
+      observationKey: 'observation-1',
+      platform: 'weixin',
+      externalAccountId: 'account-1',
+      outcome: 'PUBLISHED',
+      source: 'PUBLISHED_LIST',
+      title: '只有标题不够',
+      observedAt: '2026-07-21T12:00:00+08:00',
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('requires a post ID for successful Zhihu article observations', () => {
+    const result = PublicationObservationSchema.safeParse({
+      observationKey: 'observation-zhihu-draft',
+      platform: 'zhihu',
+      externalAccountId: 'account-1',
+      outcome: 'DRAFT_PRESENT',
+      source: 'DRAFT_DETAIL',
+      observedAt: '2026-07-21T12:00:00+08:00',
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('requires post ID, canonical URL, and publication time for published Zhihu observations', () => {
+    const base = {
+      observationKey: 'observation-zhihu-published',
+      platform: 'zhihu' as const,
+      externalAccountId: 'account-1',
+      outcome: 'PUBLISHED' as const,
+      source: 'PUBLIC_PAGE' as const,
+      platformPostId: '42',
+      observedAt: '2026-07-21T12:00:00+08:00',
+    }
+
+    expect(PublicationObservationSchema.safeParse(base).success).toBe(false)
+    expect(
+      PublicationObservationSchema.safeParse({
+        ...base,
+        canonicalUrl: 'https://zhuanlan.zhihu.com/p/42',
+      }).success,
+    ).toBe(false)
+    expect(
+      PublicationObservationSchema.safeParse({
+        ...base,
+        canonicalUrl: 'https://zhuanlan.zhihu.com/p/42',
+        publishedAt: '2026-07-21T11:55:00+08:00',
+      }).success,
+    ).toBe(true)
+  })
+})

--- a/packages/core/src/publication-inspection/__tests__/url.test.ts
+++ b/packages/core/src/publication-inspection/__tests__/url.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import samples from '../__fixtures__/url-samples.json'
+import type { PublicationPlatform } from '../types'
+import { parsePublicationUrl } from '../url'
+
+describe('parsePublicationUrl', () => {
+  for (const sample of samples) {
+    it(sample.name, () => {
+      const parsed = parsePublicationUrl(
+        sample.platform as PublicationPlatform,
+        sample.href,
+      )
+
+      expect(parsed).toMatchObject({
+        platform: sample.platform,
+        ...sample.expected,
+      })
+    })
+  }
+
+  it('rejects a valid-looking identity hosted on the wrong domain', () => {
+    expect(
+      parsePublicationUrl(
+        'zhihu',
+        'https://attacker.example/p/2000000000000000001',
+      ),
+    ).toBeNull()
+  })
+
+  it('rejects non-http protocols and URL userinfo', () => {
+    expect(parsePublicationUrl('zhihu', 'javascript:alert(1)')).toBeNull()
+    expect(
+      parsePublicationUrl(
+        'zhihu',
+        'https://user:password@zhuanlan.zhihu.com/p/2000000000000000001',
+      ),
+    ).toBeNull()
+  })
+
+  it('does not infer identities for paused platforms', () => {
+    expect(
+      parsePublicationUrl(
+        'sohu',
+        'https://www.sohu.com/a/1000000001_120000001',
+      ),
+    ).toBeNull()
+  })
+
+  it('does not guess unknown Zhihu URL shapes', () => {
+    expect(
+      parsePublicationUrl('zhihu', 'https://www.zhihu.com/question/123'),
+    ).toEqual({ platform: 'zhihu', surface: 'UNKNOWN' })
+  })
+})

--- a/packages/core/src/publication-inspection/__tests__/zhihu.test.ts
+++ b/packages/core/src/publication-inspection/__tests__/zhihu.test.ts
@@ -1,0 +1,851 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PublicationInspectRequest } from '../types'
+import {
+  decideZhihuPublishedEvidence,
+  inspectZhihuPublication,
+  parseZhihuPublishedArticleEvidence,
+  type ZhihuInspectionDependencies,
+} from '../zhihu'
+
+const POST_ID = '2000000000000000001'
+const ACCOUNT_ID = 'account-zhihu'
+const NOW = '2026-07-22T09:00:00+08:00'
+const PUBLISHED_AT = '2026-07-22T07:49:00.000Z'
+const PUBLIC_URL = `https://zhuanlan.zhihu.com/p/${POST_ID}`
+const DRAFT_URL = `${PUBLIC_URL}/edit`
+const DRAFT_API_URL = `https://zhuanlan.zhihu.com/api/articles/${POST_ID}/draft`
+
+function createRequest(
+  overrides: Partial<PublicationInspectRequest> = {},
+): PublicationInspectRequest {
+  return {
+    requestId: 'request-zhihu-1',
+    platform: 'zhihu',
+    externalAccountId: ACCOUNT_ID,
+    draft: {
+      platformPostId: POST_ID,
+      draftUrl: DRAFT_URL,
+      draftedAt: '2026-07-21T10:00:00+08:00',
+    },
+    articleHint: { title: '脱敏示例标题' },
+    limit: 20,
+    ...overrides,
+  }
+}
+
+function htmlResponse(
+  status: number,
+  url: string,
+  body = '',
+  contentType = 'text/html; charset=utf-8',
+): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    url,
+    headers: new Headers({ 'content-type': contentType }),
+    text: async () => body,
+  } as Response
+}
+
+function jsonResponse(
+  status: number,
+  url: string,
+  payload: unknown,
+  contentType = 'application/json; charset=utf-8',
+): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    url,
+    headers: new Headers({ 'content-type': contentType }),
+    json: async () => payload,
+  } as Response
+}
+
+function createDependencies(
+  fetchImpl: ZhihuInspectionDependencies['fetch'],
+  auth: Awaited<ReturnType<ZhihuInspectionDependencies['checkAuth']>> = {
+    isAuthenticated: true,
+    userId: ACCOUNT_ID,
+  },
+): ZhihuInspectionDependencies {
+  return {
+    checkAuth: vi.fn().mockResolvedValue(auth),
+    fetch: fetchImpl,
+    now: () => NOW,
+  }
+}
+
+function publishedHtmlFor(
+  articleOverrides: Record<string, unknown> = {},
+  initialDataOverride?: string,
+): string {
+  const article = {
+    id: POST_ID,
+    type: 'article',
+    articleType: 'normal',
+    author: { id: ACCOUNT_ID },
+    state: 'published',
+    status: 0,
+    isVisible: true,
+    isNormal: true,
+    url: PUBLIC_URL,
+    created: 1_784_706_540,
+    title: '脱敏后的标题 &amp; 版本',
+    content: '<p>第一段</p><p>第二段</p>',
+    ...articleOverrides,
+  }
+  const initialData =
+    initialDataOverride ??
+    JSON.stringify({
+      initialState: {
+        entities: {
+          articles: { [POST_ID]: article },
+        },
+      },
+    })
+
+  return `
+    <html>
+      <head>
+        <link href="${PUBLIC_URL}" rel="canonical">
+        <meta content="${PUBLIC_URL}" property="og:url">
+        <meta property="og:title" content="脱敏后的标题 &amp; 版本">
+        <script type="text/json" id="js-initialData">${initialData}</script>
+      </head>
+      <body><article><p>第一段</p><p>第二段</p></article></body>
+    </html>
+  `
+}
+
+const publishedHtml = publishedHtmlFor()
+
+const softNotFoundHtml = `
+  <html>
+    <head><title>你似乎来到了没有知识存在的荒原 - 知乎</title></head>
+    <body><main class="ErrorPage">你似乎来到了没有知识存在的荒原</main></body>
+  </html>
+`
+
+const draftPayload = {
+  id: POST_ID,
+  title: '脱敏草稿标题',
+  content: '<p>草稿正文</p>',
+}
+
+describe('Zhihu structured publication evidence', () => {
+  it('parses the current official js-initialData article shape', () => {
+    const parsed = parseZhihuPublishedArticleEvidence(publishedHtml, POST_ID)
+
+    expect(parsed).toEqual({
+      success: true,
+      evidence: {
+        postId: POST_ID,
+        authorId: ACCOUNT_ID,
+        title: '脱敏后的标题 & 版本',
+        publishedAt: PUBLISHED_AT,
+        bodyText: '第一段\n第二段',
+        bodyTruncated: false,
+      },
+    })
+    expect(decideZhihuPublishedEvidence(parsed, ACCOUNT_ID)).toMatchObject({
+      outcome: 'PUBLISHED',
+    })
+  })
+
+  it('requires the complete verified publication-state shape', () => {
+    const parsed = parseZhihuPublishedArticleEvidence(
+      publishedHtmlFor({ isVisible: undefined, isNormal: undefined }),
+      POST_ID,
+    )
+
+    expect(decideZhihuPublishedEvidence(parsed, ACCOUNT_ID)).toMatchObject({
+      outcome: 'REVIEW_REQUIRED',
+      errorCode: 'ZHIHU_PUBLICATION_STATE_UNVERIFIED',
+    })
+  })
+
+  it.each([
+    [
+      'a missing stable author ID',
+      publishedHtmlFor({ author: {} }),
+      'REVIEW_REQUIRED',
+      'ZHIHU_PUBLIC_AUTHOR_ID_MISSING',
+    ],
+    [
+      'an unverified publication state',
+      publishedHtmlFor({ state: 'draft' }),
+      'REVIEW_REQUIRED',
+      'ZHIHU_PUBLICATION_STATE_UNVERIFIED',
+    ],
+    [
+      'an empty structured body',
+      publishedHtmlFor({ content: '<p><br></p>' }),
+      'REVIEW_REQUIRED',
+      'ZHIHU_PUBLIC_ARTICLE_PAYLOAD_MISSING',
+    ],
+    [
+      'an invalid publication timestamp',
+      publishedHtmlFor({ created: 0 }),
+      'REVIEW_REQUIRED',
+      'ZHIHU_PUBLIC_PUBLISHED_AT_INVALID',
+    ],
+    [
+      'invalid initial JSON',
+      publishedHtmlFor({}, '{'),
+      'PARSE_ERROR',
+      'ZHIHU_PUBLIC_DETAIL_INVALID',
+    ],
+    [
+      'a missing structured article entity',
+      publishedHtmlFor(
+        {},
+        JSON.stringify({
+          initialState: { entities: { articles: {} } },
+        }),
+      ),
+      'REVIEW_REQUIRED',
+      'ZHIHU_PUBLIC_DETAIL_MISSING',
+    ],
+  ])('fails closed for %s', (_name, html, outcome, errorCode) => {
+    const parsed = parseZhihuPublishedArticleEvidence(html, POST_ID)
+    expect(decideZhihuPublishedEvidence(parsed, ACCOUNT_ID)).toMatchObject({
+      outcome,
+      errorCode,
+    })
+  })
+
+  it('rejects a structurally valid article owned by another stable account', () => {
+    const parsed = parseZhihuPublishedArticleEvidence(
+      publishedHtmlFor({ author: { id: 'another-account' } }),
+      POST_ID,
+    )
+
+    expect(decideZhihuPublishedEvidence(parsed, ACCOUNT_ID)).toMatchObject({
+      outcome: 'ACCOUNT_MISMATCH',
+      errorCode: 'ZHIHU_PUBLIC_AUTHOR_MISMATCH',
+    })
+  })
+})
+
+describe('Zhihu exact-ID publication inspector', () => {
+  it('rejects a conflict between platformPostId and the draft URL before auth', async () => {
+    const dependencies = createDependencies(vi.fn())
+    const result = await inspectZhihuPublication(
+      createRequest({
+        draft: {
+          platformPostId: POST_ID,
+          draftUrl: 'https://zhuanlan.zhihu.com/p/2000000000000000002/edit',
+          draftedAt: '2026-07-21T10:00:00+08:00',
+        },
+      }),
+      dependencies,
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'PARSE_ERROR',
+      errorCode: 'ZHIHU_POST_ID_CONFLICT',
+    })
+    expect(dependencies.checkAuth).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [
+      'non-numeric post ID',
+      { platformPostId: 'post-1' },
+      'ZHIHU_INVALID_POST_ID',
+    ],
+    ['non-editor URL', { draftUrl: PUBLIC_URL }, 'ZHIHU_INVALID_DRAFT_URL'],
+    [
+      'wrong host',
+      { draftUrl: `https://example.com/p/${POST_ID}/edit` },
+      'ZHIHU_INVALID_DRAFT_URL',
+    ],
+  ])('rejects %s', async (_name, draftOverride, errorCode) => {
+    const dependencies = createDependencies(vi.fn())
+    const result = await inspectZhihuPublication(
+      createRequest({
+        draft: {
+          ...draftOverride,
+          draftedAt: '2026-07-21T10:00:00+08:00',
+        },
+      }),
+      dependencies,
+    )
+
+    expect(result[0]).toMatchObject({ outcome: 'PARSE_ERROR', errorCode })
+    expect(dependencies.checkAuth).not.toHaveBeenCalled()
+  })
+
+  it('returns unsupported when neither exact ID anchor is available', async () => {
+    const dependencies = createDependencies(vi.fn())
+    const result = await inspectZhihuPublication(
+      createRequest({
+        draft: { draftedAt: '2026-07-21T10:00:00+08:00' },
+      }),
+      dependencies,
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'UNSUPPORTED',
+      errorCode: 'ZHIHU_POST_ID_REQUIRED',
+    })
+    expect(dependencies.checkAuth).not.toHaveBeenCalled()
+  })
+
+  it('recovers the exact ID from a verified draft URL', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(htmlResponse(200, PUBLIC_URL, publishedHtml))
+    const result = await inspectZhihuPublication(
+      createRequest({
+        draft: {
+          draftUrl: DRAFT_URL,
+          draftedAt: '2026-07-21T10:00:00+08:00',
+        },
+      }),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'PUBLISHED',
+      platformPostId: POST_ID,
+      canonicalUrl: PUBLIC_URL,
+    })
+  })
+
+  it('requires the authenticated account to match exactly', async () => {
+    const dependencies = createDependencies(vi.fn(), {
+      isAuthenticated: true,
+      userId: 'another-account',
+    })
+    const result = await inspectZhihuPublication(createRequest(), dependencies)
+
+    expect(result[0]).toMatchObject({
+      outcome: 'ACCOUNT_MISMATCH',
+      errorCode: 'ACCOUNT_MISMATCH',
+    })
+    expect(dependencies.fetch).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [{ isAuthenticated: false }, 'LOGIN_REQUIRED', 'ZHIHU_LOGIN_REQUIRED'],
+    [
+      { isAuthenticated: false, error: 'network failed' },
+      'FETCH_ERROR',
+      'ZHIHU_AUTH_CHECK_FAILED',
+    ],
+    [{ isAuthenticated: true }, 'PARSE_ERROR', 'ZHIHU_ACCOUNT_ID_MISSING'],
+  ])('maps account result %# explicitly', async (auth, outcome, errorCode) => {
+    const dependencies = createDependencies(vi.fn(), auth)
+    const result = await inspectZhihuPublication(createRequest(), dependencies)
+
+    expect(result[0]).toMatchObject({ outcome, errorCode })
+    expect(dependencies.fetch).not.toHaveBeenCalled()
+  })
+
+  it('requires the exact current Zhihu soft-not-found title', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(
+        htmlResponse(
+          200,
+          PUBLIC_URL,
+          softNotFoundHtml.replace(' - 知乎</title>', '</title>'),
+        ),
+      )
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'PARSE_ERROR',
+      errorCode: 'ZHIHU_UNEXPECTED_PUBLIC_PAGE',
+    })
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns PUBLISHED only when response URL and HTML identity agree', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(htmlResponse(200, PUBLIC_URL, publishedHtml))
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        outcome: 'PUBLISHED',
+        source: 'PUBLIC_PAGE',
+        platformPostId: POST_ID,
+        canonicalUrl: PUBLIC_URL,
+        title: '脱敏后的标题 & 版本',
+        publishedAt: PUBLISHED_AT,
+        bodyText: '第一段\n第二段',
+        observedAt: NOW,
+      }),
+    ])
+    expect(fetch).toHaveBeenCalledWith(
+      PUBLIC_URL,
+      expect.objectContaining({
+        method: 'GET',
+        credentials: 'omit',
+        cache: 'no-store',
+        redirect: 'follow',
+      }),
+    )
+  })
+
+  it('accepts a matching og:url as the explicit public identity marker', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(
+        htmlResponse(
+          200,
+          PUBLIC_URL,
+          publishedHtml.replace(
+            `<link href="${PUBLIC_URL}" rel="canonical">`,
+            '',
+          ),
+        ),
+      )
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'PUBLISHED',
+      canonicalUrl: PUBLIC_URL,
+    })
+  })
+
+  it('does not treat canonical metadata alone as a published article', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(
+        htmlResponse(
+          200,
+          PUBLIC_URL,
+          `<meta property="og:url" content="${PUBLIC_URL}">`,
+        ),
+      )
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'REVIEW_REQUIRED',
+      errorCode: 'ZHIHU_PUBLIC_DETAIL_MISSING',
+    })
+  })
+
+  it.each([
+    [
+      'missing author ID',
+      publishedHtmlFor({ author: {} }),
+      'REVIEW_REQUIRED',
+      'ZHIHU_PUBLIC_AUTHOR_ID_MISSING',
+    ],
+    [
+      'foreign author ID',
+      publishedHtmlFor({ author: { id: 'another-account' } }),
+      'ACCOUNT_MISMATCH',
+      'ZHIHU_PUBLIC_AUTHOR_MISMATCH',
+    ],
+    [
+      'unverified publication state',
+      publishedHtmlFor({ isVisible: false }),
+      'REVIEW_REQUIRED',
+      'ZHIHU_PUBLICATION_STATE_UNVERIFIED',
+    ],
+    [
+      'structured URL for another article',
+      publishedHtmlFor({
+        url: 'https://zhuanlan.zhihu.com/p/2000000000000000002',
+      }),
+      'REVIEW_REQUIRED',
+      'ZHIHU_PUBLICATION_STATE_UNVERIFIED',
+    ],
+    [
+      'missing article content',
+      publishedHtmlFor({ content: '' }),
+      'REVIEW_REQUIRED',
+      'ZHIHU_PUBLIC_ARTICLE_PAYLOAD_MISSING',
+    ],
+    [
+      'invalid publication timestamp',
+      publishedHtmlFor({ created: Number.POSITIVE_INFINITY }),
+      'REVIEW_REQUIRED',
+      'ZHIHU_PUBLIC_PUBLISHED_AT_INVALID',
+    ],
+  ])(
+    'fails closed when structured public evidence has %s',
+    async (_name, html, outcome, errorCode) => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValue(htmlResponse(200, PUBLIC_URL, html))
+      const result = await inspectZhihuPublication(
+        createRequest(),
+        createDependencies(fetch),
+      )
+
+      expect(result[0]).toMatchObject({ outcome, errorCode })
+      expect(result[0]).not.toHaveProperty('canonicalUrl')
+    },
+  )
+
+  it('rejects a 2xx public page without canonical or og:url identity', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(
+        htmlResponse(200, PUBLIC_URL, '<html><h1>只有标题</h1></html>'),
+      )
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'PARSE_ERROR',
+      errorCode: 'ZHIHU_UNEXPECTED_PUBLIC_PAGE',
+    })
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    [
+      'an article element',
+      softNotFoundHtml.replace(
+        '</main>',
+        '</main><article>contradictory content</article>',
+      ),
+    ],
+    [
+      'identity metadata',
+      softNotFoundHtml.replace(
+        '</head>',
+        `<link rel="canonical" href="${PUBLIC_URL}"></head>`,
+      ),
+    ],
+  ])('does not accept a soft-not-found title with %s', async (_name, body) => {
+    const fetch = vi.fn().mockResolvedValue(htmlResponse(200, PUBLIC_URL, body))
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'PARSE_ERROR',
+      errorCode: 'ZHIHU_UNEXPECTED_PUBLIC_PAGE',
+    })
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects identity metadata for another article', async () => {
+    const anotherUrl = 'https://zhuanlan.zhihu.com/p/2000000000000000002'
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(
+        htmlResponse(
+          200,
+          PUBLIC_URL,
+          `<link rel="canonical" href="${anotherUrl}">`,
+        ),
+      )
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'PARSE_ERROR',
+      errorCode: 'ZHIHU_UNEXPECTED_PUBLIC_PAGE',
+    })
+  })
+
+  it('rejects a redirected 2xx page even when its HTML claims the expected ID', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(
+        htmlResponse(200, 'https://www.zhihu.com/', publishedHtml),
+      )
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'PARSE_ERROR',
+      errorCode: 'ZHIHU_UNEXPECTED_PUBLIC_PAGE',
+    })
+  })
+
+  it.each([
+    ['a hard 404', htmlResponse(404, PUBLIC_URL)],
+    [
+      'the strict Zhihu soft 404',
+      htmlResponse(200, PUBLIC_URL, softNotFoundHtml),
+    ],
+  ])(
+    'returns DRAFT_PRESENT after %s and an exact draft API response',
+    async (_name, publicResponse) => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValueOnce(publicResponse)
+        .mockResolvedValueOnce(jsonResponse(200, DRAFT_API_URL, draftPayload))
+      const result = await inspectZhihuPublication(
+        createRequest(),
+        createDependencies(fetch),
+      )
+
+      expect(result[0]).toMatchObject({
+        outcome: 'DRAFT_PRESENT',
+        source: 'DRAFT_DETAIL',
+        platformPostId: POST_ID,
+        title: '脱敏草稿标题',
+        bodyText: '草稿正文',
+      })
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
+        DRAFT_API_URL,
+        expect.objectContaining({
+          method: 'GET',
+          credentials: 'include',
+          redirect: 'error',
+          headers: expect.objectContaining({
+            Accept: 'application/json',
+            'x-requested-with': 'fetch',
+          }),
+        }),
+      )
+    },
+  )
+
+  it.each([
+    [401, 'LOGIN_REQUIRED', 'ZHIHU_LOGIN_REQUIRED'],
+    [403, 'FETCH_ERROR', 'ZHIHU_DRAFT_HTTP_403'],
+    [429, 'FETCH_ERROR', 'ZHIHU_DRAFT_RATE_LIMITED'],
+    [500, 'FETCH_ERROR', 'ZHIHU_DRAFT_HTTP_500'],
+  ])('maps draft API HTTP %s to %s', async (status, outcome, errorCode) => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(htmlResponse(404, PUBLIC_URL))
+      .mockResolvedValueOnce(jsonResponse(status, DRAFT_API_URL, {}))
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({ outcome, errorCode })
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects draft JSON returned from an unexpected response URL', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(htmlResponse(404, PUBLIC_URL))
+      .mockResolvedValueOnce(
+        jsonResponse(
+          200,
+          `https://zhuanlan.zhihu.com/api/articles/${POST_ID}/redirected`,
+          draftPayload,
+        ),
+      )
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'PARSE_ERROR',
+      errorCode: 'ZHIHU_DRAFT_UNEXPECTED_RESPONSE_URL',
+    })
+  })
+
+  it('returns a fetch error when the draft API request fails', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(htmlResponse(404, PUBLIC_URL))
+      .mockRejectedValueOnce(new Error('offline'))
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'FETCH_ERROR',
+      errorCode: 'ZHIHU_DRAFT_FETCH_ERROR',
+    })
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects a non-JSON draft API response before parsing it', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(htmlResponse(404, PUBLIC_URL))
+      .mockResolvedValueOnce(
+        jsonResponse(200, DRAFT_API_URL, draftPayload, 'text/html'),
+      )
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'PARSE_ERROR',
+      errorCode: 'ZHIHU_DRAFT_UNEXPECTED_CONTENT_TYPE',
+    })
+  })
+
+  it('rejects invalid JSON from the draft API', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(htmlResponse(404, PUBLIC_URL))
+      .mockResolvedValueOnce(
+        htmlResponse(200, DRAFT_API_URL, '{', 'application/json'),
+      )
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'PARSE_ERROR',
+      errorCode: 'ZHIHU_DRAFT_JSON_INVALID',
+    })
+  })
+
+  it.each([
+    ['non-object payload', null, 'ZHIHU_DRAFT_RESPONSE_INVALID'],
+    [
+      'numeric ID',
+      { ...draftPayload, id: Number(POST_ID) },
+      'ZHIHU_DRAFT_ID_MISMATCH',
+    ],
+    [
+      'different ID',
+      { ...draftPayload, id: '2000000000000000002' },
+      'ZHIHU_DRAFT_ID_MISMATCH',
+    ],
+    [
+      'whitespace-padded ID',
+      { ...draftPayload, id: ` ${POST_ID} ` },
+      'ZHIHU_DRAFT_ID_MISMATCH',
+    ],
+    [
+      'empty title',
+      { ...draftPayload, title: '   ' },
+      'ZHIHU_DRAFT_RESPONSE_INVALID',
+    ],
+    [
+      'empty content',
+      { ...draftPayload, content: '<p><br></p>' },
+      'ZHIHU_DRAFT_RESPONSE_INVALID',
+    ],
+  ])('rejects draft API %s', async (_name, payload, errorCode) => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(htmlResponse(404, PUBLIC_URL))
+      .mockResolvedValueOnce(jsonResponse(200, DRAFT_API_URL, payload))
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({ outcome: 'PARSE_ERROR', errorCode })
+  })
+
+  it.each([
+    ['a public hard 404', htmlResponse(404, PUBLIC_URL)],
+    [
+      'a public strict soft 404',
+      htmlResponse(200, PUBLIC_URL, softNotFoundHtml),
+    ],
+  ])(
+    'returns NOT_FOUND only after %s and a draft API 404',
+    async (_name, publicResponse) => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValueOnce(publicResponse)
+        .mockResolvedValueOnce(jsonResponse(404, DRAFT_API_URL, {}))
+      const result = await inspectZhihuPublication(
+        createRequest(),
+        createDependencies(fetch),
+      )
+
+      expect(result[0]).toMatchObject({
+        outcome: 'NOT_FOUND',
+        source: 'DRAFT_DETAIL',
+        platformPostId: POST_ID,
+      })
+      expect(fetch).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it.each([
+    [429, 'ZHIHU_RATE_LIMITED'],
+    [403, 'ZHIHU_HTTP_403'],
+    [500, 'ZHIHU_HTTP_500'],
+  ])('maps HTTP %s to an explicit fetch error', async (status, errorCode) => {
+    const fetch = vi.fn().mockResolvedValue(htmlResponse(status, PUBLIC_URL))
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({ outcome: 'FETCH_ERROR', errorCode })
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps a login redirect explicitly', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(
+        htmlResponse(200, 'https://www.zhihu.com/signin?next=%2Fp%2Fexample'),
+      )
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'LOGIN_REQUIRED',
+      errorCode: 'ZHIHU_LOGIN_REQUIRED',
+    })
+  })
+
+  it('maps network failure explicitly without probing the editor', async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error('offline'))
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0]).toMatchObject({
+      outcome: 'FETCH_ERROR',
+      errorCode: 'ZHIHU_FETCH_ERROR',
+    })
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('caps extracted body text at the observation contract limit', async () => {
+    const longBody = '内'.repeat(50_010)
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(
+        htmlResponse(200, PUBLIC_URL, publishedHtmlFor({ content: longBody })),
+      )
+    const result = await inspectZhihuPublication(
+      createRequest(),
+      createDependencies(fetch),
+    )
+
+    expect(result[0].bodyText).toHaveLength(50_000)
+    expect(result[0].bodyTruncated).toBe(true)
+  })
+})

--- a/packages/core/src/publication-inspection/index.ts
+++ b/packages/core/src/publication-inspection/index.ts
@@ -1,0 +1,4 @@
+export * from './types'
+export * from './url'
+export * from './sanitize'
+export * from './zhihu'

--- a/packages/core/src/publication-inspection/sanitize.ts
+++ b/packages/core/src/publication-inspection/sanitize.ts
@@ -1,0 +1,133 @@
+const BOUNDARY_URL_FIELDS = ['postUrl', 'url'] as const
+
+type BoundaryUrlField = (typeof BOUNDARY_URL_FIELDS)[number]
+
+/**
+ * The smallest structural shape needed to sanitize a sync result. Extra fields
+ * are preserved so callers do not lose postId, status, timestamps, or errors.
+ */
+export interface SyncResultBoundaryInput {
+  platform?: unknown
+  postId?: unknown
+  postUrl?: unknown
+  url?: unknown
+}
+
+export type SanitizedSyncResult<T extends SyncResultBoundaryInput> = Omit<
+  T,
+  BoundaryUrlField
+> &
+  Partial<Record<BoundaryUrlField, string>>
+
+const SENSITIVE_QUERY_COMPONENTS = new Set([
+  'auth',
+  'authorization',
+  'credential',
+  'credentials',
+  'password',
+  'passwd',
+  'secret',
+  'session',
+  'sig',
+  'sign',
+  'signature',
+  'ticket',
+  'token',
+])
+
+const SENSITIVE_COMPACT_QUERY_KEYS = new Set([
+  'accesstoken',
+  'apikey',
+  'authtoken',
+  'clientsecret',
+  'idtoken',
+  'refreshtoken',
+  'sessionid',
+  'sessionkey',
+])
+
+function splitQueryKey(key: string): string[] {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+}
+
+function isSensitiveQueryKey(key: string): boolean {
+  const components = splitQueryKey(key)
+  if (
+    components.some((component) => SENSITIVE_QUERY_COMPONENTS.has(component))
+  ) {
+    return true
+  }
+
+  return SENSITIVE_COMPACT_QUERY_KEYS.has(components.join(''))
+}
+
+function isWeixinPlatform(platform: unknown): boolean {
+  return (
+    typeof platform === 'string' && platform.trim().toLowerCase() === 'weixin'
+  )
+}
+
+/**
+ * Sanitize a URL before it crosses the extension boundary or is persisted.
+ *
+ * WeChat draft URLs are never safe at this boundary because they currently
+ * carry a live login token. Other platforms retain only absolute HTTP(S) URLs
+ * without userinfo, sensitive query parameters, or fragments.
+ */
+export function sanitizeBoundaryUrl(
+  platform: unknown,
+  value: unknown,
+): string | undefined {
+  if (isWeixinPlatform(platform) || typeof value !== 'string') {
+    return undefined
+  }
+
+  try {
+    const parsed = new URL(value)
+    if (
+      (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') ||
+      parsed.username !== '' ||
+      parsed.password !== ''
+    ) {
+      return undefined
+    }
+
+    for (const key of [...parsed.searchParams.keys()]) {
+      if (isSensitiveQueryKey(key)) {
+        parsed.searchParams.delete(key)
+      }
+    }
+    parsed.hash = ''
+
+    return parsed.href
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Return a non-mutating, boundary-safe copy of a sync result.
+ *
+ * postId and all non-URL fields are deliberately preserved. Unsafe URL fields
+ * are removed rather than replaced with a misleading or unusable value.
+ */
+export function sanitizeSyncResultForBoundary<
+  T extends SyncResultBoundaryInput,
+>(result: T): SanitizedSyncResult<T> {
+  const sanitized = { ...result } as Record<string, unknown>
+
+  for (const field of BOUNDARY_URL_FIELDS) {
+    const safeUrl = sanitizeBoundaryUrl(result.platform, result[field])
+    if (safeUrl) {
+      sanitized[field] = safeUrl
+    } else {
+      delete sanitized[field]
+    }
+  }
+
+  return sanitized as SanitizedSyncResult<T>
+}

--- a/packages/core/src/publication-inspection/types.ts
+++ b/packages/core/src/publication-inspection/types.ts
@@ -1,0 +1,196 @@
+import { z } from 'zod'
+
+export const PublicationPlatformSchema = z.enum([
+  'toutiao',
+  'zhihu',
+  'sohu',
+  'weixin',
+])
+
+export type PublicationPlatform = z.infer<typeof PublicationPlatformSchema>
+
+export const PublicationInspectionCapabilitySchema = z.enum([
+  'account_identity',
+  'full_sync_result',
+  'publication_inspect',
+  'published_list',
+  'public_url',
+])
+
+export type PublicationInspectionCapability = z.infer<
+  typeof PublicationInspectionCapabilitySchema
+>
+
+export const SyncerBridgeInfoSchema = z.object({
+  apiVersion: z.literal('2.0'),
+  extensionVersion: z.string().min(1),
+  capabilities: z.array(PublicationInspectionCapabilitySchema),
+})
+
+export type SyncerBridgeInfo = z.infer<typeof SyncerBridgeInfoSchema>
+
+export const SyncerAccountV2Schema = z.object({
+  platform: PublicationPlatformSchema,
+  externalAccountId: z.string().trim().min(1).max(500),
+  displayName: z.string().trim().min(1).max(500),
+  avatarUrl: z.string().url().max(2_000).optional(),
+  homepage: z.string().url().max(2_000).optional(),
+  capabilities: z.array(PublicationInspectionCapabilitySchema).max(10),
+})
+
+export type SyncerAccountV2 = z.infer<typeof SyncerAccountV2Schema>
+
+export const SYNCER_BRIDGE_REQUEST_ID_MAX_LENGTH = 128
+
+export const PublicationInspectRequestSchema = z.object({
+  requestId: z.string().trim().min(1).max(SYNCER_BRIDGE_REQUEST_ID_MAX_LENGTH),
+  platform: PublicationPlatformSchema,
+  externalAccountId: z.string().trim().min(1).max(500),
+  draft: z.object({
+    platformPostId: z.string().trim().min(1).max(500).optional(),
+    draftUrl: z.string().url().max(4_096).optional(),
+    draftedAt: z.string().datetime({ offset: true }),
+  }),
+  articleHint: z.object({
+    title: z.string().min(1).max(500),
+    publishedAfter: z.string().datetime({ offset: true }).optional(),
+    publishedBefore: z.string().datetime({ offset: true }).optional(),
+  }),
+  limit: z.number().int().min(1).max(20),
+})
+
+export type PublicationInspectRequest = z.infer<
+  typeof PublicationInspectRequestSchema
+>
+
+export const PublicationObservationOutcomeSchema = z.enum([
+  'DRAFT_PRESENT',
+  'PENDING_REVIEW',
+  'REJECTED',
+  'SCHEDULED',
+  'PUBLISHED',
+  'NOT_FOUND',
+  'DELETED',
+  'REVIEW_REQUIRED',
+  'ACCOUNT_MISMATCH',
+  'LOGIN_REQUIRED',
+  'UNSUPPORTED',
+  'FETCH_ERROR',
+  'PARSE_ERROR',
+])
+
+export type PublicationObservationOutcome = z.infer<
+  typeof PublicationObservationOutcomeSchema
+>
+
+export const ZHIHU_ARTICLE_SUCCESS_OUTCOMES: readonly PublicationObservationOutcome[] =
+  [
+    'DRAFT_PRESENT',
+    'PENDING_REVIEW',
+    'REJECTED',
+    'SCHEDULED',
+    'PUBLISHED',
+    'NOT_FOUND',
+    'DELETED',
+  ]
+
+export const PublicationObservationSourceSchema = z.enum([
+  'DRAFT_DETAIL',
+  'DRAFT_LIST',
+  'PLATFORM_DETAIL',
+  'PUBLISHED_LIST',
+  'PUBLIC_PAGE',
+])
+
+export type PublicationObservationSource = z.infer<
+  typeof PublicationObservationSourceSchema
+>
+
+export const PublicationObservationSchema = z
+  .object({
+    observationKey: z.string().min(1).max(500),
+    platform: PublicationPlatformSchema,
+    externalAccountId: z.string().trim().min(1).max(500),
+    outcome: PublicationObservationOutcomeSchema,
+    source: PublicationObservationSourceSchema,
+    platformPostId: z.string().trim().min(1).max(500).optional(),
+    canonicalUrl: z.string().url().max(4_096).optional(),
+    title: z.string().max(500).optional(),
+    publishedAt: z.string().datetime({ offset: true }).optional(),
+    bodyText: z.string().max(50_000).optional(),
+    bodyTruncated: z.boolean().optional(),
+    observedAt: z.string().datetime({ offset: true }),
+    errorCode: z.string().max(100).optional(),
+    errorMessage: z.string().max(2_000).optional(),
+  })
+  .superRefine((value, ctx) => {
+    const isError = [
+      'LOGIN_REQUIRED',
+      'ACCOUNT_MISMATCH',
+      'REVIEW_REQUIRED',
+      'UNSUPPORTED',
+      'FETCH_ERROR',
+      'PARSE_ERROR',
+    ].includes(value.outcome)
+
+    if (isError && !value.errorCode) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'error outcomes require errorCode',
+        path: ['errorCode'],
+      })
+    }
+
+    if (
+      value.outcome === 'PUBLISHED' &&
+      !value.platformPostId &&
+      !value.canonicalUrl
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'published observations require platformPostId or canonicalUrl',
+        path: ['platformPostId'],
+      })
+    }
+
+    if (
+      value.platform === 'zhihu' &&
+      ZHIHU_ARTICLE_SUCCESS_OUTCOMES.includes(value.outcome) &&
+      !value.platformPostId
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'successful Zhihu observations require platformPostId',
+        path: ['platformPostId'],
+      })
+    }
+
+    if (
+      value.platform === 'zhihu' &&
+      value.outcome === 'PUBLISHED' &&
+      !value.canonicalUrl
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'published Zhihu observations require canonicalUrl',
+        path: ['canonicalUrl'],
+      })
+    }
+
+    if (
+      value.platform === 'zhihu' &&
+      value.outcome === 'PUBLISHED' &&
+      !value.publishedAt
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'published Zhihu observations require publishedAt',
+        path: ['publishedAt'],
+      })
+    }
+  })
+
+export type PublicationObservation = z.infer<
+  typeof PublicationObservationSchema
+>

--- a/packages/core/src/publication-inspection/url.ts
+++ b/packages/core/src/publication-inspection/url.ts
@@ -1,0 +1,72 @@
+import type { PublicationPlatform } from './types'
+
+export type PublicationSurface = 'DRAFT' | 'PUBLISHED' | 'UNKNOWN'
+
+export interface ParsedPublicationUrl {
+  platform: PublicationPlatform
+  surface: PublicationSurface
+  postId?: string
+  accountId?: string
+  canonicalUrl?: string
+}
+
+const ZHIHU_ALLOWED_HOSTS = new Set(['www.zhihu.com', 'zhuanlan.zhihu.com'])
+
+function safeUrl(href: string): URL | null {
+  try {
+    const url = new URL(href)
+    if (
+      (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+      url.username !== '' ||
+      url.password !== ''
+    ) {
+      return null
+    }
+    return url
+  } catch {
+    return null
+  }
+}
+
+function cleanPath(pathname: string): string {
+  if (pathname === '/') return '/'
+  return pathname.replace(/\/+$/, '')
+}
+
+function parseZhihu(url: URL): ParsedPublicationUrl {
+  const articleMatch = cleanPath(url.pathname).match(/^\/p\/(\d+)(\/edit)?$/)
+  if (url.hostname === 'zhuanlan.zhihu.com' && articleMatch) {
+    const postId = articleMatch[1]
+    const isDraft = Boolean(articleMatch[2])
+    return {
+      platform: 'zhihu',
+      surface: isDraft ? 'DRAFT' : 'PUBLISHED',
+      postId,
+      canonicalUrl: isDraft
+        ? undefined
+        : `https://zhuanlan.zhihu.com/p/${postId}`,
+    }
+  }
+
+  return { platform: 'zhihu', surface: 'UNKNOWN' }
+}
+
+/**
+ * Parse only URL shapes verified for an active publication inspector.
+ * Paused platform vocabulary remains in the protocol, but its URLs are not
+ * inferred until that platform has passed the same rollout gate as Zhihu.
+ */
+export function parsePublicationUrl(
+  platform: PublicationPlatform,
+  href: string,
+): ParsedPublicationUrl | null {
+  if (platform !== 'zhihu') return null
+
+  const url = safeUrl(href)
+  if (!url) return null
+
+  url.hostname = url.hostname.toLowerCase()
+  if (!ZHIHU_ALLOWED_HOSTS.has(url.hostname)) return null
+
+  return parseZhihu(url)
+}

--- a/packages/core/src/publication-inspection/zhihu.ts
+++ b/packages/core/src/publication-inspection/zhihu.ts
@@ -1,0 +1,1024 @@
+import type { AuthResult } from '../types'
+import type {
+  PublicationInspectRequest,
+  PublicationObservation,
+  PublicationObservationOutcome,
+  PublicationObservationSource,
+} from './types'
+import { parsePublicationUrl } from './url'
+
+const ZHIHU_PUBLIC_ORIGIN = 'https://zhuanlan.zhihu.com'
+const ZHIHU_SOFT_NOT_FOUND_TITLE = '你似乎来到了没有知识存在的荒原 - 知乎'
+const MAX_TITLE_LENGTH = 500
+const MAX_BODY_TEXT_LENGTH = 50_000
+
+export interface ZhihuInspectionDependencies {
+  checkAuth(): Promise<AuthResult>
+  fetch(url: string, options?: RequestInit): Promise<Response>
+  now?: () => string
+}
+
+interface ObservationDetails {
+  outcome: PublicationObservationOutcome
+  source: PublicationObservationSource
+  platformPostId?: string
+  canonicalUrl?: string
+  title?: string
+  publishedAt?: string
+  bodyText?: string
+  bodyTruncated?: boolean
+  errorCode?: string
+  errorMessage?: string
+}
+
+interface PageContent {
+  html: string
+  responseUrl: string
+}
+
+type PageProbe =
+  | { kind: 'FOUND'; page: PageContent }
+  | { kind: 'NOT_FOUND' }
+  | { kind: 'OBSERVATION'; observation: PublicationObservation }
+
+interface DraftContent {
+  title: string
+  bodyText: string
+  bodyTruncated: boolean
+}
+
+export interface ZhihuPublishedArticleEvidence {
+  postId: string
+  authorId: string
+  title: string
+  publishedAt: string
+  bodyText: string
+  bodyTruncated: boolean
+}
+
+export type ZhihuPublishedEvidenceFailureReason =
+  | 'INITIAL_DATA_MISSING'
+  | 'INITIAL_DATA_DUPLICATE'
+  | 'INITIAL_DATA_INVALID'
+  | 'ARTICLE_MISSING'
+  | 'ARTICLE_ID_MISMATCH'
+  | 'AUTHOR_ID_MISSING'
+  | 'PUBLICATION_STATE_UNVERIFIED'
+  | 'PUBLISHED_AT_INVALID'
+  | 'ARTICLE_PAYLOAD_MISSING'
+
+export type ZhihuPublishedEvidenceParseResult =
+  | { success: true; evidence: ZhihuPublishedArticleEvidence }
+  | { success: false; reason: ZhihuPublishedEvidenceFailureReason }
+
+export type ZhihuPublishedEvidenceDecision =
+  | { outcome: 'PUBLISHED'; evidence: ZhihuPublishedArticleEvidence }
+  | {
+      outcome: 'REVIEW_REQUIRED' | 'ACCOUNT_MISMATCH' | 'PARSE_ERROR'
+      errorCode: string
+      errorMessage: string
+    }
+
+type DraftProbe =
+  | { kind: 'FOUND'; draft: DraftContent }
+  | { kind: 'NOT_FOUND' }
+  | { kind: 'OBSERVATION'; observation: PublicationObservation }
+
+type PostIdResolution =
+  | { success: true; postId: string }
+  | {
+      success: false
+      outcome: 'UNSUPPORTED' | 'PARSE_ERROR'
+      errorCode: string
+      errorMessage: string
+    }
+
+function createObservation(
+  request: PublicationInspectRequest,
+  observedAt: string,
+  details: ObservationDetails,
+): PublicationObservation {
+  return {
+    observationKey: `zhihu:${request.requestId}:${details.source}:${details.outcome}`,
+    platform: 'zhihu',
+    externalAccountId: request.externalAccountId,
+    observedAt,
+    ...details,
+  }
+}
+
+function resolvePostId(request: PublicationInspectRequest): PostIdResolution {
+  if (request.platform !== 'zhihu') {
+    return {
+      success: false,
+      outcome: 'UNSUPPORTED',
+      errorCode: 'ZHIHU_PLATFORM_REQUIRED',
+      errorMessage: 'The Zhihu inspector only accepts Zhihu requests.',
+    }
+  }
+
+  const platformPostId = request.draft.platformPostId?.trim()
+  if (platformPostId && !/^\d+$/.test(platformPostId)) {
+    return {
+      success: false,
+      outcome: 'PARSE_ERROR',
+      errorCode: 'ZHIHU_INVALID_POST_ID',
+      errorMessage: 'The Zhihu post ID must contain digits only.',
+    }
+  }
+
+  let draftUrlPostId: string | undefined
+  if (request.draft.draftUrl) {
+    const parsedDraftUrl = parsePublicationUrl('zhihu', request.draft.draftUrl)
+    if (
+      !parsedDraftUrl ||
+      parsedDraftUrl.surface !== 'DRAFT' ||
+      !parsedDraftUrl.postId
+    ) {
+      return {
+        success: false,
+        outcome: 'PARSE_ERROR',
+        errorCode: 'ZHIHU_INVALID_DRAFT_URL',
+        errorMessage: 'The draft URL is not a verified Zhihu editor URL.',
+      }
+    }
+    draftUrlPostId = parsedDraftUrl.postId
+  }
+
+  if (platformPostId && draftUrlPostId && platformPostId !== draftUrlPostId) {
+    return {
+      success: false,
+      outcome: 'PARSE_ERROR',
+      errorCode: 'ZHIHU_POST_ID_CONFLICT',
+      errorMessage:
+        'The Zhihu post ID and draft URL identify different articles.',
+    }
+  }
+
+  const postId = platformPostId ?? draftUrlPostId
+  if (!postId) {
+    return {
+      success: false,
+      outcome: 'UNSUPPORTED',
+      errorCode: 'ZHIHU_POST_ID_REQUIRED',
+      errorMessage:
+        'Exact Zhihu inspection requires a post ID or verified draft URL.',
+    }
+  }
+
+  return { success: true, postId }
+}
+
+function isSignInUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return (
+      url.hostname === 'www.zhihu.com' &&
+      url.pathname.replace(/\/+$/, '') === '/signin'
+    )
+  } catch {
+    return false
+  }
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&#x([0-9a-f]+);/gi, (_match, hex: string) => {
+      const codePoint = Number.parseInt(hex, 16)
+      return codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : ''
+    })
+    .replace(/&#(\d+);/g, (_match, decimal: string) => {
+      const codePoint = Number.parseInt(decimal, 10)
+      return codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : ''
+    })
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&amp;/gi, '&')
+    .replace(/&nbsp;/gi, ' ')
+}
+
+function parseTagAttributes(tag: string): Map<string, string> {
+  const attributes = new Map<string, string>()
+  const withoutTagName = tag
+    .replace(/^<\s*[a-z][^\s/>]*/i, '')
+    .replace(/\/?>\s*$/, '')
+  const attributePattern =
+    /([^\s"'<>\/=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g
+
+  for (const match of withoutTagName.matchAll(attributePattern)) {
+    const name = match[1]?.toLowerCase()
+    if (!name) continue
+    attributes.set(
+      name,
+      decodeHtmlEntities(match[2] ?? match[3] ?? match[4] ?? ''),
+    )
+  }
+
+  return attributes
+}
+
+function extractIdentityUrls(html: string): string[] {
+  const urls: string[] = []
+  for (const match of html.matchAll(/<(?:link|meta)\b[^>]*>/gi)) {
+    const tag = match[0]
+    const attributes = parseTagAttributes(tag)
+
+    if (/^<link\b/i.test(tag)) {
+      const rel = attributes.get('rel')?.toLowerCase().split(/\s+/) ?? []
+      const href = attributes.get('href')
+      if (rel.includes('canonical') && href) urls.push(href)
+      continue
+    }
+
+    const property = (
+      attributes.get('property') ??
+      attributes.get('name') ??
+      ''
+    ).toLowerCase()
+    const content = attributes.get('content')
+    if (property === 'og:url' && content) urls.push(content)
+  }
+
+  return [...new Set(urls)]
+}
+
+function hasExpectedIdentity(
+  html: string,
+  postId: string,
+  surface: 'PUBLISHED' | 'DRAFT',
+): boolean {
+  const identityUrls = extractIdentityUrls(html)
+  if (identityUrls.length === 0) return false
+
+  return identityUrls.every((identityUrl) => {
+    const parsed = parsePublicationUrl('zhihu', identityUrl)
+    if (!parsed || parsed.postId !== postId || parsed.surface === 'UNKNOWN') {
+      return false
+    }
+
+    // A draft editor may declare either its editor URL or the corresponding
+    // public canonical URL. The final response URL still has to be /edit.
+    return surface === 'DRAFT' || parsed.surface === 'PUBLISHED'
+  })
+}
+
+function normalizeText(value: string): string {
+  const withoutMarkup = value
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, ' ')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(?:p|div|section|article|h[1-6]|li|blockquote)>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+
+  return decodeHtmlEntities(withoutMarkup)
+    .replace(/[^\S\r\n]+/g, ' ')
+    .replace(/\s*\n\s*/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function extractJsonScriptContents(html: string, id: string): string[] {
+  const contents: string[] = []
+  for (const match of html.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/gi)) {
+    const tag = match[0].slice(0, match[0].indexOf('>') + 1)
+    if (parseTagAttributes(tag).get('id') === id) {
+      contents.push(match[1] ?? '')
+    }
+  }
+  return contents
+}
+
+function unixSecondsToIso(value: unknown): string | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined
+  }
+
+  const date = new Date(value * 1_000)
+  return Number.isFinite(date.getTime()) ? date.toISOString() : undefined
+}
+
+/**
+ * Parse the structured article entity currently emitted by Zhihu's official
+ * public article frontend in #js-initialData. This parser is deliberately pure
+ * and fail-closed: canonical metadata alone is not publication evidence.
+ */
+export function parseZhihuPublishedArticleEvidence(
+  html: string,
+  postId: string,
+): ZhihuPublishedEvidenceParseResult {
+  const initialDataScripts = extractJsonScriptContents(html, 'js-initialData')
+  if (initialDataScripts.length === 0) {
+    return { success: false, reason: 'INITIAL_DATA_MISSING' }
+  }
+  if (initialDataScripts.length !== 1) {
+    return { success: false, reason: 'INITIAL_DATA_DUPLICATE' }
+  }
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(initialDataScripts[0])
+  } catch {
+    return { success: false, reason: 'INITIAL_DATA_INVALID' }
+  }
+
+  if (!isRecord(payload)) {
+    return { success: false, reason: 'INITIAL_DATA_INVALID' }
+  }
+
+  const initialState = payload.initialState
+  const entities = isRecord(initialState) ? initialState.entities : undefined
+  const articles = isRecord(entities) ? entities.articles : undefined
+  if (
+    !isRecord(articles) ||
+    !Object.prototype.hasOwnProperty.call(articles, postId)
+  ) {
+    return { success: false, reason: 'ARTICLE_MISSING' }
+  }
+
+  const article = articles[postId]
+  if (!isRecord(article)) {
+    return { success: false, reason: 'ARTICLE_MISSING' }
+  }
+  if (typeof article.id !== 'string' || article.id !== postId) {
+    return { success: false, reason: 'ARTICLE_ID_MISMATCH' }
+  }
+
+  const author = article.author
+  const authorId =
+    isRecord(author) && typeof author.id === 'string' ? author.id.trim() : ''
+  if (!authorId) {
+    return { success: false, reason: 'AUTHOR_ID_MISSING' }
+  }
+
+  const structuredUrl =
+    typeof article.url === 'string'
+      ? parsePublicationUrl('zhihu', article.url)
+      : null
+  if (
+    article.type !== 'article' ||
+    article.articleType !== 'normal' ||
+    article.state !== 'published' ||
+    article.status !== 0 ||
+    article.isVisible !== true ||
+    article.isNormal !== true ||
+    structuredUrl?.surface !== 'PUBLISHED' ||
+    structuredUrl.postId !== postId
+  ) {
+    return { success: false, reason: 'PUBLICATION_STATE_UNVERIFIED' }
+  }
+
+  const publishedAt = unixSecondsToIso(article.created)
+  if (!publishedAt) {
+    return { success: false, reason: 'PUBLISHED_AT_INVALID' }
+  }
+
+  const title =
+    typeof article.title === 'string' ? normalizeText(article.title) : ''
+  const fullBodyText =
+    typeof article.content === 'string' ? normalizeText(article.content) : ''
+  if (!title || !fullBodyText) {
+    return { success: false, reason: 'ARTICLE_PAYLOAD_MISSING' }
+  }
+
+  return {
+    success: true,
+    evidence: {
+      postId,
+      authorId,
+      title: title.slice(0, MAX_TITLE_LENGTH),
+      publishedAt,
+      bodyText: fullBodyText.slice(0, MAX_BODY_TEXT_LENGTH),
+      bodyTruncated: fullBodyText.length > MAX_BODY_TEXT_LENGTH,
+    },
+  }
+}
+
+/** Decide whether structured public evidence is strong enough to cross the boundary. */
+export function decideZhihuPublishedEvidence(
+  parsed: ZhihuPublishedEvidenceParseResult,
+  expectedAccountId: string,
+): ZhihuPublishedEvidenceDecision {
+  if (!parsed.success) {
+    switch (parsed.reason) {
+      case 'INITIAL_DATA_MISSING':
+      case 'ARTICLE_MISSING':
+        return {
+          outcome: 'REVIEW_REQUIRED',
+          errorCode: 'ZHIHU_PUBLIC_DETAIL_MISSING',
+          errorMessage:
+            'The public Zhihu page did not expose structured article detail.',
+        }
+      case 'AUTHOR_ID_MISSING':
+        return {
+          outcome: 'REVIEW_REQUIRED',
+          errorCode: 'ZHIHU_PUBLIC_AUTHOR_ID_MISSING',
+          errorMessage:
+            'The public Zhihu article did not expose a stable author ID.',
+        }
+      case 'PUBLICATION_STATE_UNVERIFIED':
+        return {
+          outcome: 'REVIEW_REQUIRED',
+          errorCode: 'ZHIHU_PUBLICATION_STATE_UNVERIFIED',
+          errorMessage:
+            'The structured Zhihu article state did not prove a public publication.',
+        }
+      case 'PUBLISHED_AT_INVALID':
+        return {
+          outcome: 'REVIEW_REQUIRED',
+          errorCode: 'ZHIHU_PUBLIC_PUBLISHED_AT_INVALID',
+          errorMessage:
+            'The public Zhihu article lacked a valid publication timestamp.',
+        }
+      case 'ARTICLE_PAYLOAD_MISSING':
+        return {
+          outcome: 'REVIEW_REQUIRED',
+          errorCode: 'ZHIHU_PUBLIC_ARTICLE_PAYLOAD_MISSING',
+          errorMessage:
+            'The public Zhihu article lacked a complete structured article payload.',
+        }
+      default:
+        return {
+          outcome: 'PARSE_ERROR',
+          errorCode: 'ZHIHU_PUBLIC_DETAIL_INVALID',
+          errorMessage:
+            'The public Zhihu article detail had an invalid structure.',
+        }
+    }
+  }
+
+  if (parsed.evidence.authorId !== expectedAccountId.trim()) {
+    return {
+      outcome: 'ACCOUNT_MISMATCH',
+      errorCode: 'ZHIHU_PUBLIC_AUTHOR_MISMATCH',
+      errorMessage:
+        'The public Zhihu article does not belong to the bound account.',
+    }
+  }
+
+  return { outcome: 'PUBLISHED', evidence: parsed.evidence }
+}
+
+function extractDocumentTitle(html: string): string | undefined {
+  const titleMatch = html.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i)
+  const normalized = normalizeText(titleMatch?.[1] ?? '')
+  return normalized || undefined
+}
+
+function isStrictSoftNotFoundPage(html: string): boolean {
+  return (
+    extractIdentityUrls(html).length === 0 &&
+    !/<article\b[^>]*>/i.test(html) &&
+    extractDocumentTitle(html) === ZHIHU_SOFT_NOT_FOUND_TITLE
+  )
+}
+
+function contentTypeIsHtml(response: Response): boolean {
+  const contentType = response.headers.get('content-type')?.toLowerCase()
+  return Boolean(
+    contentType &&
+    (contentType.includes('text/html') ||
+      contentType.includes('application/xhtml+xml')),
+  )
+}
+
+function contentTypeIsJson(response: Response): boolean {
+  const contentType = response.headers.get('content-type')?.toLowerCase()
+  return Boolean(
+    contentType &&
+    (contentType.includes('application/json') || contentType.includes('+json')),
+  )
+}
+
+async function fetchPage(
+  request: PublicationInspectRequest,
+  postId: string,
+  source: PublicationObservationSource,
+  url: string,
+  dependencies: ZhihuInspectionDependencies,
+  observedAt: string,
+): Promise<PageProbe> {
+  let response: Response
+  try {
+    response = await dependencies.fetch(url, {
+      method: 'GET',
+      credentials: 'omit',
+      redirect: 'follow',
+      cache: 'no-store',
+      headers: {
+        Accept: 'text/html,application/xhtml+xml',
+      },
+    })
+  } catch {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'FETCH_ERROR',
+        source,
+        platformPostId: postId,
+        errorCode: 'ZHIHU_FETCH_ERROR',
+        errorMessage: 'The Zhihu page request failed.',
+      }),
+    }
+  }
+
+  if (isSignInUrl(response.url) || response.status === 401) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'LOGIN_REQUIRED',
+        source,
+        platformPostId: postId,
+        errorCode: 'ZHIHU_LOGIN_REQUIRED',
+        errorMessage: 'Zhihu requires an authenticated session.',
+      }),
+    }
+  }
+
+  if (response.status === 404) return { kind: 'NOT_FOUND' }
+
+  if (response.status === 429) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'FETCH_ERROR',
+        source,
+        platformPostId: postId,
+        errorCode: 'ZHIHU_RATE_LIMITED',
+        errorMessage: 'Zhihu rate-limited the inspection request.',
+      }),
+    }
+  }
+
+  if (response.status === 403) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'FETCH_ERROR',
+        source,
+        platformPostId: postId,
+        errorCode: 'ZHIHU_HTTP_403',
+        errorMessage: 'Zhihu denied the inspection request.',
+      }),
+    }
+  }
+
+  if (!response.ok) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'FETCH_ERROR',
+        source,
+        platformPostId: postId,
+        errorCode: `ZHIHU_HTTP_${response.status}`,
+        errorMessage: `Zhihu returned HTTP ${response.status}.`,
+      }),
+    }
+  }
+
+  if (!contentTypeIsHtml(response)) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'PARSE_ERROR',
+        source,
+        platformPostId: postId,
+        errorCode: 'ZHIHU_UNEXPECTED_CONTENT_TYPE',
+        errorMessage: 'Zhihu returned a non-HTML response.',
+      }),
+    }
+  }
+
+  try {
+    return {
+      kind: 'FOUND',
+      page: {
+        html: await response.text(),
+        responseUrl: response.url,
+      },
+    }
+  } catch {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'FETCH_ERROR',
+        source,
+        platformPostId: postId,
+        errorCode: 'ZHIHU_BODY_READ_FAILED',
+        errorMessage: 'The Zhihu response body could not be read.',
+      }),
+    }
+  }
+}
+
+async function fetchDraft(
+  request: PublicationInspectRequest,
+  postId: string,
+  dependencies: ZhihuInspectionDependencies,
+  observedAt: string,
+): Promise<DraftProbe> {
+  const draftApiUrl = `${ZHIHU_PUBLIC_ORIGIN}/api/articles/${postId}/draft`
+  let response: Response
+  try {
+    response = await dependencies.fetch(draftApiUrl, {
+      method: 'GET',
+      credentials: 'include',
+      redirect: 'error',
+      cache: 'no-store',
+      headers: {
+        Accept: 'application/json',
+        'x-requested-with': 'fetch',
+      },
+    })
+  } catch {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'FETCH_ERROR',
+        source: 'DRAFT_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ZHIHU_DRAFT_FETCH_ERROR',
+        errorMessage: 'The Zhihu draft-detail request failed.',
+      }),
+    }
+  }
+
+  if (isSignInUrl(response.url) || response.status === 401) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'LOGIN_REQUIRED',
+        source: 'DRAFT_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ZHIHU_LOGIN_REQUIRED',
+        errorMessage: 'Zhihu requires an authenticated session.',
+      }),
+    }
+  }
+
+  if (response.url !== draftApiUrl) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'PARSE_ERROR',
+        source: 'DRAFT_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ZHIHU_DRAFT_UNEXPECTED_RESPONSE_URL',
+        errorMessage:
+          'The Zhihu draft-detail response came from an unexpected URL.',
+      }),
+    }
+  }
+
+  if (response.status === 404) return { kind: 'NOT_FOUND' }
+
+  if (response.status === 429) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'FETCH_ERROR',
+        source: 'DRAFT_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ZHIHU_DRAFT_RATE_LIMITED',
+        errorMessage: 'Zhihu rate-limited the draft-detail request.',
+      }),
+    }
+  }
+
+  if (response.status === 403) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'FETCH_ERROR',
+        source: 'DRAFT_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ZHIHU_DRAFT_HTTP_403',
+        errorMessage: 'Zhihu denied the draft-detail request.',
+      }),
+    }
+  }
+
+  if (!response.ok) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'FETCH_ERROR',
+        source: 'DRAFT_DETAIL',
+        platformPostId: postId,
+        errorCode: `ZHIHU_DRAFT_HTTP_${response.status}`,
+        errorMessage: `Zhihu returned HTTP ${response.status} for the draft-detail request.`,
+      }),
+    }
+  }
+
+  if (!contentTypeIsJson(response)) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'PARSE_ERROR',
+        source: 'DRAFT_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ZHIHU_DRAFT_UNEXPECTED_CONTENT_TYPE',
+        errorMessage: 'Zhihu returned a non-JSON draft-detail response.',
+      }),
+    }
+  }
+
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'PARSE_ERROR',
+        source: 'DRAFT_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ZHIHU_DRAFT_JSON_INVALID',
+        errorMessage: 'The Zhihu draft-detail response was not valid JSON.',
+      }),
+    }
+  }
+
+  if (
+    typeof payload !== 'object' ||
+    payload === null ||
+    Array.isArray(payload)
+  ) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'PARSE_ERROR',
+        source: 'DRAFT_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ZHIHU_DRAFT_RESPONSE_INVALID',
+        errorMessage: 'The Zhihu draft-detail response had an invalid shape.',
+      }),
+    }
+  }
+
+  const draft = payload as Record<string, unknown>
+  if (typeof draft.id !== 'string' || draft.id !== postId) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'PARSE_ERROR',
+        source: 'DRAFT_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ZHIHU_DRAFT_ID_MISMATCH',
+        errorMessage:
+          'The Zhihu draft-detail response identified a different article.',
+      }),
+    }
+  }
+
+  if (typeof draft.title !== 'string' || typeof draft.content !== 'string') {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'PARSE_ERROR',
+        source: 'DRAFT_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ZHIHU_DRAFT_RESPONSE_INVALID',
+        errorMessage:
+          'The Zhihu draft-detail response lacked title or content.',
+      }),
+    }
+  }
+
+  const title = normalizeText(draft.title)
+  const fullBodyText = normalizeText(draft.content)
+  if (!title || !fullBodyText) {
+    return {
+      kind: 'OBSERVATION',
+      observation: createObservation(request, observedAt, {
+        outcome: 'PARSE_ERROR',
+        source: 'DRAFT_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ZHIHU_DRAFT_RESPONSE_INVALID',
+        errorMessage:
+          'The Zhihu draft-detail response had empty title or content.',
+      }),
+    }
+  }
+
+  return {
+    kind: 'FOUND',
+    draft: {
+      title: title.slice(0, MAX_TITLE_LENGTH),
+      bodyText: fullBodyText.slice(0, MAX_BODY_TEXT_LENGTH),
+      bodyTruncated: fullBodyText.length > MAX_BODY_TEXT_LENGTH,
+    },
+  }
+}
+
+function responseUrlMatches(
+  responseUrl: string,
+  postId: string,
+  surface: 'PUBLISHED' | 'DRAFT',
+): boolean {
+  const parsed = parsePublicationUrl('zhihu', responseUrl)
+  return parsed?.surface === surface && parsed.postId === postId
+}
+
+/**
+ * Inspect a Zhihu article only through the stable article ID created during
+ * draft delivery. This deliberately does not scan drafts or published lists.
+ */
+export async function inspectZhihuPublication(
+  request: PublicationInspectRequest,
+  dependencies: ZhihuInspectionDependencies,
+): Promise<PublicationObservation[]> {
+  const observedAt = dependencies.now?.() ?? new Date().toISOString()
+  const resolution = resolvePostId(request)
+  if (!resolution.success) {
+    return [
+      createObservation(request, observedAt, {
+        outcome: resolution.outcome,
+        source: 'DRAFT_DETAIL',
+        errorCode: resolution.errorCode,
+        errorMessage: resolution.errorMessage,
+      }),
+    ]
+  }
+
+  const { postId } = resolution
+  let auth: AuthResult
+  try {
+    auth = await dependencies.checkAuth()
+  } catch {
+    return [
+      createObservation(request, observedAt, {
+        outcome: 'FETCH_ERROR',
+        source: 'PLATFORM_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ZHIHU_AUTH_CHECK_FAILED',
+        errorMessage: 'The Zhihu account check failed.',
+      }),
+    ]
+  }
+
+  if (!auth.isAuthenticated) {
+    return [
+      createObservation(request, observedAt, {
+        outcome: auth.error ? 'FETCH_ERROR' : 'LOGIN_REQUIRED',
+        source: 'PLATFORM_DETAIL',
+        platformPostId: postId,
+        errorCode: auth.error
+          ? 'ZHIHU_AUTH_CHECK_FAILED'
+          : 'ZHIHU_LOGIN_REQUIRED',
+        errorMessage: auth.error
+          ? 'The Zhihu account check failed.'
+          : 'Zhihu requires an authenticated session.',
+      }),
+    ]
+  }
+
+  if (!auth.userId) {
+    return [
+      createObservation(request, observedAt, {
+        outcome: 'PARSE_ERROR',
+        source: 'PLATFORM_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ZHIHU_ACCOUNT_ID_MISSING',
+        errorMessage: 'The authenticated Zhihu account has no stable ID.',
+      }),
+    ]
+  }
+
+  if (auth.userId !== request.externalAccountId) {
+    return [
+      createObservation(request, observedAt, {
+        outcome: 'ACCOUNT_MISMATCH',
+        source: 'PLATFORM_DETAIL',
+        platformPostId: postId,
+        errorCode: 'ACCOUNT_MISMATCH',
+        errorMessage:
+          'The active Zhihu account does not match the bound account.',
+      }),
+    ]
+  }
+
+  const publicUrl = `${ZHIHU_PUBLIC_ORIGIN}/p/${postId}`
+  const publicProbe = await fetchPage(
+    request,
+    postId,
+    'PUBLIC_PAGE',
+    publicUrl,
+    dependencies,
+    observedAt,
+  )
+
+  if (publicProbe.kind === 'OBSERVATION') {
+    return [publicProbe.observation]
+  }
+
+  if (publicProbe.kind === 'FOUND') {
+    if (
+      !responseUrlMatches(publicProbe.page.responseUrl, postId, 'PUBLISHED')
+    ) {
+      return [
+        createObservation(request, observedAt, {
+          outcome: 'PARSE_ERROR',
+          source: 'PUBLIC_PAGE',
+          platformPostId: postId,
+          errorCode: 'ZHIHU_UNEXPECTED_PUBLIC_PAGE',
+          errorMessage:
+            'The public page did not prove the expected Zhihu article identity.',
+        }),
+      ]
+    }
+
+    const hasNotFoundTitle =
+      extractDocumentTitle(publicProbe.page.html) === ZHIHU_SOFT_NOT_FOUND_TITLE
+    if (hasNotFoundTitle) {
+      if (!isStrictSoftNotFoundPage(publicProbe.page.html)) {
+        return [
+          createObservation(request, observedAt, {
+            outcome: 'PARSE_ERROR',
+            source: 'PUBLIC_PAGE',
+            platformPostId: postId,
+            errorCode: 'ZHIHU_UNEXPECTED_PUBLIC_PAGE',
+            errorMessage:
+              'The public page had contradictory not-found markers.',
+          }),
+        ]
+      }
+    } else {
+      if (!hasExpectedIdentity(publicProbe.page.html, postId, 'PUBLISHED')) {
+        return [
+          createObservation(request, observedAt, {
+            outcome: 'PARSE_ERROR',
+            source: 'PUBLIC_PAGE',
+            platformPostId: postId,
+            errorCode: 'ZHIHU_UNEXPECTED_PUBLIC_PAGE',
+            errorMessage:
+              'The public page did not prove the expected Zhihu article identity.',
+          }),
+        ]
+      }
+
+      const decision = decideZhihuPublishedEvidence(
+        parseZhihuPublishedArticleEvidence(publicProbe.page.html, postId),
+        request.externalAccountId,
+      )
+      if (decision.outcome !== 'PUBLISHED') {
+        return [
+          createObservation(request, observedAt, {
+            outcome: decision.outcome,
+            source: 'PUBLIC_PAGE',
+            platformPostId: postId,
+            errorCode: decision.errorCode,
+            errorMessage: decision.errorMessage,
+          }),
+        ]
+      }
+
+      return [
+        createObservation(request, observedAt, {
+          outcome: 'PUBLISHED',
+          source: 'PUBLIC_PAGE',
+          platformPostId: postId,
+          canonicalUrl: publicUrl,
+          title: decision.evidence.title,
+          publishedAt: decision.evidence.publishedAt,
+          bodyText: decision.evidence.bodyText,
+          ...(decision.evidence.bodyTruncated ? { bodyTruncated: true } : {}),
+        }),
+      ]
+    }
+  }
+
+  const draftProbe = await fetchDraft(request, postId, dependencies, observedAt)
+
+  if (draftProbe.kind === 'OBSERVATION') {
+    return [draftProbe.observation]
+  }
+
+  if (draftProbe.kind === 'NOT_FOUND') {
+    return [
+      createObservation(request, observedAt, {
+        outcome: 'NOT_FOUND',
+        source: 'DRAFT_DETAIL',
+        platformPostId: postId,
+      }),
+    ]
+  }
+
+  return [
+    createObservation(request, observedAt, {
+      outcome: 'DRAFT_PRESENT',
+      source: 'DRAFT_DETAIL',
+      platformPostId: postId,
+      title: draftProbe.draft.title,
+      bodyText: draftProbe.draft.bodyText,
+      ...(draftProbe.draft.bodyTruncated ? { bodyTruncated: true } : {}),
+    }),
+  ]
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     index: 'src/index.ts',
     'adapters/index': 'src/adapters/index.ts',
     'runtime/index': 'src/runtime/index.ts',
+    'publication-inspection/index': 'src/publication-inspection/index.ts',
   },
   format: ['cjs', 'esm'],
   dts: true,

--- a/packages/extension/__tests__/adapter-auth-cache.test.ts
+++ b/packages/extension/__tests__/adapter-auth-cache.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authTestState = vi.hoisted(() => ({
+  checkAuth: vi.fn(),
+  otherCheckAuth: vi.fn(),
+  metas: [
+    {
+      id: 'zhihu',
+      name: '知乎',
+      icon: 'zhihu.svg',
+      homepage: 'https://www.zhihu.com',
+      capabilities: ['article', 'draft'],
+    },
+  ],
+  sohuMeta: {
+    id: 'sohu',
+    name: '搜狐',
+    icon: 'sohu.svg',
+    homepage: 'https://mp.sohu.com',
+    capabilities: ['article', 'draft'],
+  },
+}))
+
+vi.mock('@wechatsync/core', () => {
+  class DummyAdapter {
+    meta = authTestState.metas[0]
+  }
+
+  return {
+    adapterRegistry: {
+      setRuntime: vi.fn(),
+      register: vi.fn(),
+      getAllMeta: vi.fn(() => authTestState.metas),
+      get: vi.fn(async (platformId: string) => {
+        const meta = authTestState.metas.find(
+          (candidate) => candidate.id === platformId,
+        )
+        if (!meta) return null
+
+        return {
+          meta,
+          checkAuth:
+            platformId === 'sohu'
+              ? authTestState.otherCheckAuth
+              : authTestState.checkAuth,
+        }
+      }),
+      getPreprocessConfig: vi.fn(),
+      getPreprocessConfigs: vi.fn(),
+    },
+    ZhihuAdapter: DummyAdapter,
+    JuejinAdapter: DummyAdapter,
+    WeiboAdapter: DummyAdapter,
+    BilibiliAdapter: DummyAdapter,
+    BaijiahaoAdapter: DummyAdapter,
+    CSDNAdapter: DummyAdapter,
+    YuqueAdapter: DummyAdapter,
+    DoubanAdapter: DummyAdapter,
+    SohuAdapter: DummyAdapter,
+    XueqiuAdapter: DummyAdapter,
+    WeixinAdapter: DummyAdapter,
+    WoshipmAdapter: DummyAdapter,
+    Cto51Adapter: DummyAdapter,
+    ImoocAdapter: DummyAdapter,
+    OschinaAdapter: DummyAdapter,
+    SegmentfaultAdapter: DummyAdapter,
+    CnblogsAdapter: DummyAdapter,
+    ZipDownloadAdapter: DummyAdapter,
+    EastmoneyAdapter: DummyAdapter,
+  }
+})
+
+import { checkAllPlatformsAuth, clearAuthCache } from '../src/adapters/index.ts'
+
+const completeAuthResult = {
+  isAuthenticated: true,
+  username: '测试账号',
+  userId: 'stable-account-123',
+  avatar: 'https://example.com/avatar.png',
+}
+
+describe('adapter auth cache', () => {
+  beforeEach(async () => {
+    authTestState.metas.splice(1)
+    authTestState.checkAuth.mockReset()
+    authTestState.checkAuth.mockResolvedValue(completeAuthResult)
+    authTestState.otherCheckAuth.mockReset()
+    authTestState.otherCheckAuth.mockResolvedValue({
+      ...completeAuthResult,
+      userId: 'stable-sohu-account-456',
+    })
+    await clearAuthCache()
+  })
+
+  it('preserves the stable account ID and avatar returned by checkAuth', async () => {
+    const results = await checkAllPlatformsAuth(true)
+
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject(completeAuthResult)
+
+    const storage = await chrome.storage.local.get('authCache')
+    expect(storage.authCache.zhihu).toMatchObject(completeAuthResult)
+  })
+
+  it('returns the stable account ID and avatar from a valid cache hit', async () => {
+    await checkAllPlatformsAuth(true)
+    authTestState.checkAuth.mockClear()
+
+    const results = await checkAllPlatformsAuth()
+
+    expect(authTestState.checkAuth).not.toHaveBeenCalled()
+    expect(results[0]).toMatchObject(completeAuthResult)
+  })
+
+  it('checks only the requested platform and never invokes unrelated adapters', async () => {
+    authTestState.metas.push(authTestState.sohuMeta)
+    authTestState.otherCheckAuth.mockRejectedValue(
+      new Error('unrelated platform must not be checked'),
+    )
+
+    const results = await checkAllPlatformsAuth(true, ['zhihu'])
+
+    expect(results.map((result) => result.id)).toEqual(['zhihu'])
+    expect(authTestState.checkAuth).toHaveBeenCalledTimes(1)
+    expect(authTestState.otherCheckAuth).not.toHaveBeenCalled()
+  })
+
+  it('returns only the requested platform from cache without checking others', async () => {
+    authTestState.metas.push(authTestState.sohuMeta)
+    await checkAllPlatformsAuth(true)
+    authTestState.checkAuth.mockClear()
+    authTestState.otherCheckAuth.mockClear()
+
+    const results = await checkAllPlatformsAuth(false, ['zhihu'])
+
+    expect(results.map((result) => result.id)).toEqual(['zhihu'])
+    expect(authTestState.checkAuth).not.toHaveBeenCalled()
+    expect(authTestState.otherCheckAuth).not.toHaveBeenCalled()
+  })
+
+  it('keeps the legacy all-platform behavior when no target filter is supplied', async () => {
+    authTestState.metas.push(authTestState.sohuMeta)
+
+    const results = await checkAllPlatformsAuth(true)
+
+    expect(results.map((result) => result.id)).toEqual(['zhihu', 'sohu'])
+    expect(authTestState.checkAuth).toHaveBeenCalledTimes(1)
+    expect(authTestState.otherCheckAuth).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/extension/__tests__/bridge-background.test.ts
+++ b/packages/extension/__tests__/bridge-background.test.ts
@@ -1,0 +1,450 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildSyncerAccountsV2,
+  createUnsupportedPublicationObservation,
+  runPublicationInspection,
+  validateBridgeMessageSender,
+  validateGetAccountsV2Payload,
+  validateInspectPublicationPayload,
+} from '../src/background/bridge-v2'
+
+function sender(
+  overrides: Partial<chrome.runtime.MessageSender> = {},
+): chrome.runtime.MessageSender {
+  return {
+    origin: 'http://localhost',
+    url: 'http://localhost/workspaces/ws-001/articles/article-001',
+    frameId: 0,
+    tab: {
+      id: 42,
+      url: 'http://localhost/workspaces/ws-001/articles/article-001',
+    } as chrome.tabs.Tab,
+    ...overrides,
+  }
+}
+
+const inspectPayload = {
+  requestId: 'inspect-001',
+  platform: 'toutiao',
+  externalAccountId: 'account-001',
+  draft: {
+    platformPostId: 'draft-001',
+    draftedAt: '2026-07-21T10:00:00+08:00',
+  },
+  articleHint: {
+    title: 'Phase 0 publication verification',
+    publishedAfter: '2026-07-21T10:00:00+08:00',
+  },
+  limit: 20,
+}
+
+describe('Bridge v2 background sender boundary', () => {
+  it('accepts only a tab-backed top-frame sender from http://localhost', () => {
+    expect(validateBridgeMessageSender(sender())).toEqual({
+      success: true,
+      data: {
+        origin: 'http://localhost',
+        tabId: 42,
+        url: 'http://localhost/workspaces/ws-001/articles/article-001',
+      },
+    })
+  })
+
+  it.each([
+    sender({ origin: 'http://localhost:3000', url: 'http://localhost:3000' }),
+    sender({
+      origin: 'http://127.0.0.1',
+      url: 'http://127.0.0.1',
+      tab: { id: 42, url: 'http://127.0.0.1' } as chrome.tabs.Tab,
+    }),
+    sender({ frameId: 1 }),
+    sender({ tab: undefined }),
+    sender({ url: 'https://localhost/workspaces/ws-001' }),
+    sender({
+      tab: { id: 42, url: 'http://localhost:3000' } as chrome.tabs.Tab,
+    }),
+  ])('rejects a non-canonical, sub-frame, or tabless sender', (candidate) => {
+    expect(validateBridgeMessageSender(candidate)).toEqual({
+      success: false,
+      code: 'SENDER_NOT_ALLOWED',
+    })
+  })
+})
+
+describe('Bridge v2 background payload validation', () => {
+  it('independently validates and normalizes getAccountsV2 payloads', () => {
+    expect(
+      validateGetAccountsV2Payload({
+        platforms: ['toutiao', 'weixin'],
+        forceRefresh: true,
+      }),
+    ).toEqual({
+      success: true,
+      data: {
+        platforms: ['toutiao', 'weixin'],
+        forceRefresh: true,
+      },
+    })
+  })
+
+  it.each([
+    undefined,
+    { platforms: ['toutiao', 'toutiao'] },
+    { platforms: ['baijiahao'] },
+    { forceRefresh: 'yes' },
+    { forceRefresh: false, extra: true },
+  ])('rejects an invalid getAccountsV2 payload', (payload) => {
+    expect(validateGetAccountsV2Payload(payload)).toEqual({
+      success: false,
+      code: 'INVALID_PAYLOAD',
+    })
+  })
+
+  it('independently validates inspectPublication and binds its request ID', () => {
+    expect(
+      validateInspectPublicationPayload(inspectPayload, 'inspect-001'),
+    ).toEqual({ success: true, data: inspectPayload })
+
+    expect(
+      validateInspectPublicationPayload(inspectPayload, 'another-request'),
+    ).toEqual({ success: false, code: 'INVALID_PAYLOAD' })
+  })
+
+  it('binds inspection payloads after normalizing both request IDs', () => {
+    expect(
+      validateInspectPublicationPayload(
+        { ...inspectPayload, requestId: ' inspect-001 ' },
+        ' inspect-001 ',
+      ),
+    ).toEqual({ success: true, data: inspectPayload })
+  })
+
+  it.each([
+    { ...inspectPayload, limit: 21 },
+    { ...inspectPayload, platform: 'baijiahao' },
+    { ...inspectPayload, unexpected: true },
+    {
+      ...inspectPayload,
+      draft: { ...inspectPayload.draft, unexpected: true },
+    },
+    {
+      ...inspectPayload,
+      articleHint: { ...inspectPayload.articleHint, unexpected: true },
+    },
+  ])('rejects an invalid inspectPublication payload', (payload) => {
+    expect(validateInspectPublicationPayload(payload, 'inspect-001')).toEqual({
+      success: false,
+      code: 'INVALID_PAYLOAD',
+    })
+  })
+})
+
+describe('Bridge v2 account projection', () => {
+  it('keeps only authenticated Phase 0 accounts with a stable user ID', () => {
+    const accounts = buildSyncerAccountsV2([
+      {
+        id: 'toutiao',
+        name: 'Toutiao',
+        isAuthenticated: true,
+        username: ' Creator A ',
+        userId: ' account-toutiao ',
+        avatar: 'https://cdn.example/avatar.png',
+        homepage: 'https://mp.toutiao.com/profile_v4/index',
+      },
+      {
+        id: 'zhihu',
+        name: 'Zhihu',
+        isAuthenticated: true,
+        username: 'Zhihu Creator',
+        userId: 'account-zhihu',
+      },
+      {
+        id: 'sohu',
+        name: 'Sohu',
+        isAuthenticated: true,
+        username: 'No stable ID',
+      },
+      {
+        id: 'weixin',
+        name: 'WeChat',
+        isAuthenticated: true,
+        userId: 'account-weixin',
+        avatar: 'data:image/png;base64,secret',
+        homepage: 'javascript:alert(1)',
+      },
+      {
+        id: 'baijiahao',
+        name: 'Out of scope',
+        isAuthenticated: true,
+        userId: 'account-baijiahao',
+      },
+    ])
+
+    expect(accounts).toEqual([
+      {
+        platform: 'toutiao',
+        externalAccountId: 'account-toutiao',
+        displayName: 'Creator A',
+        avatarUrl: 'https://cdn.example/avatar.png',
+        homepage: 'https://mp.toutiao.com/profile_v4/index',
+        capabilities: ['account_identity'],
+      },
+      {
+        platform: 'zhihu',
+        externalAccountId: 'account-zhihu',
+        displayName: 'Zhihu Creator',
+        capabilities: ['account_identity', 'publication_inspect', 'public_url'],
+      },
+      {
+        platform: 'weixin',
+        externalAccountId: 'account-weixin',
+        displayName: 'WeChat',
+        capabilities: ['account_identity'],
+      },
+    ])
+  })
+
+  it('applies the requested platform filter and emits one account per platform', () => {
+    const accounts = buildSyncerAccountsV2(
+      [
+        {
+          id: 'toutiao',
+          isAuthenticated: true,
+          userId: 'first',
+          username: 'First',
+        },
+        {
+          id: 'toutiao',
+          isAuthenticated: true,
+          userId: 'second',
+          username: 'Second',
+        },
+        {
+          id: 'zhihu',
+          isAuthenticated: true,
+          userId: 'zhihu-account',
+          username: 'Zhihu',
+        },
+      ],
+      ['toutiao'],
+    )
+
+    expect(accounts).toHaveLength(1)
+    expect(accounts[0]).toMatchObject({
+      platform: 'toutiao',
+      externalAccountId: 'first',
+      capabilities: ['account_identity'],
+    })
+  })
+})
+
+describe('Bridge v2 unsupported inspection prototype', () => {
+  it('returns an explicit UNSUPPORTED observation instead of NOT_FOUND', () => {
+    const request = validateInspectPublicationPayload(
+      inspectPayload,
+      'inspect-001',
+    )
+    expect(request.success).toBe(true)
+    if (!request.success) return
+
+    expect(
+      createUnsupportedPublicationObservation(
+        request.data,
+        '2026-07-21T12:00:00.000Z',
+      ),
+    ).toEqual({
+      observationKey: 'bridge-v2:inspect-001:toutiao:unsupported',
+      platform: 'toutiao',
+      externalAccountId: 'account-001',
+      outcome: 'UNSUPPORTED',
+      source: 'PLATFORM_DETAIL',
+      observedAt: '2026-07-21T12:00:00.000Z',
+      errorCode: 'PUBLICATION_INSPECTION_NOT_IMPLEMENTED',
+      errorMessage:
+        'Publication inspection is not implemented for toutiao in Phase 0.',
+    })
+  })
+
+  it('does not execute an inspector for a paused platform', async () => {
+    const request = validateInspectPublicationPayload(
+      {
+        ...inspectPayload,
+        platform: 'sohu',
+        externalAccountId: 'account-sohu',
+      },
+      'inspect-001',
+    )
+    expect(request.success).toBe(true)
+    if (!request.success) return
+
+    const inspectPublication = vi.fn().mockResolvedValue([])
+    const observations = await runPublicationInspection(request.data, {
+      inspectPublication,
+    })
+
+    expect(inspectPublication).not.toHaveBeenCalled()
+    expect(observations).toHaveLength(1)
+    expect(observations[0]).toMatchObject({
+      platform: 'sohu',
+      outcome: 'UNSUPPORTED',
+    })
+  })
+})
+
+describe('Bridge v2 inspection execution boundary', () => {
+  const request = {
+    ...inspectPayload,
+    platform: 'zhihu' as const,
+    externalAccountId: 'zhihu-account',
+    draft: {
+      platformPostId: '42',
+      draftedAt: inspectPayload.draft.draftedAt,
+    },
+  }
+
+  it('accepts a valid adapter result and canonicalizes its public URL', async () => {
+    await expect(
+      runPublicationInspection(request, {
+        inspectPublication: async () => [
+          {
+            observationKey: 'zhihu:42:published',
+            platform: 'zhihu',
+            externalAccountId: 'zhihu-account',
+            outcome: 'PUBLISHED',
+            source: 'PUBLIC_PAGE',
+            platformPostId: '42',
+            canonicalUrl: 'https://zhuanlan.zhihu.com/p/42?utm_source=test',
+            publishedAt: '2026-07-21T11:55:00.000Z',
+            observedAt: '2026-07-21T12:00:00.000Z',
+          },
+        ],
+      }),
+    ).resolves.toMatchObject([
+      {
+        outcome: 'PUBLISHED',
+        canonicalUrl: 'https://zhuanlan.zhihu.com/p/42',
+      },
+    ])
+  })
+
+  it.each([
+    [
+      'an observed post ID different from the request',
+      {
+        platformPostId: '43',
+        canonicalUrl: 'https://zhuanlan.zhihu.com/p/43',
+      },
+    ],
+    [
+      'a canonical URL for another post ID',
+      {
+        platformPostId: '42',
+        canonicalUrl: 'https://zhuanlan.zhihu.com/p/43',
+      },
+    ],
+    [
+      'a missing canonical URL',
+      {
+        platformPostId: '42',
+        canonicalUrl: undefined,
+      },
+    ],
+    [
+      'a missing publication time',
+      {
+        platformPostId: '42',
+        canonicalUrl: 'https://zhuanlan.zhihu.com/p/42',
+        publishedAt: undefined,
+      },
+    ],
+  ])('rejects published Zhihu output with %s', async (_name, overrides) => {
+    const observations = await runPublicationInspection(request, {
+      inspectPublication: async () =>
+        [
+          {
+            observationKey: 'zhihu:42:published-invalid',
+            platform: 'zhihu',
+            externalAccountId: 'zhihu-account',
+            outcome: 'PUBLISHED',
+            source: 'PUBLIC_PAGE',
+            publishedAt: '2026-07-21T11:55:00.000Z',
+            observedAt: '2026-07-21T12:00:00.000Z',
+            ...overrides,
+          },
+        ] as never,
+    })
+
+    expect(observations[0]).toMatchObject({
+      outcome: 'PARSE_ERROR',
+      errorCode: 'INVALID_INSPECTION_RESULT',
+    })
+  })
+
+  it('rejects a successful Zhihu draft observation for another post ID', async () => {
+    const observations = await runPublicationInspection(request, {
+      inspectPublication: async () => [
+        {
+          observationKey: 'zhihu:43:draft',
+          platform: 'zhihu',
+          externalAccountId: 'zhihu-account',
+          outcome: 'DRAFT_PRESENT',
+          source: 'DRAFT_DETAIL',
+          platformPostId: '43',
+          observedAt: '2026-07-21T12:00:00.000Z',
+        },
+      ],
+    })
+
+    expect(observations[0]).toMatchObject({
+      outcome: 'PARSE_ERROR',
+      errorCode: 'INVALID_INSPECTION_RESULT',
+    })
+  })
+
+  it.each([
+    [],
+    [
+      {
+        observationKey: 'wrong-account',
+        platform: 'zhihu',
+        externalAccountId: 'another-account',
+        outcome: 'NOT_FOUND',
+        source: 'PUBLIC_PAGE',
+        observedAt: '2026-07-21T12:00:00.000Z',
+      },
+    ],
+  ])('turns invalid adapter output into PARSE_ERROR', async (value) => {
+    const observations = await runPublicationInspection(request, {
+      inspectPublication: async () => value as never,
+    })
+    expect(observations[0]).toMatchObject({
+      outcome: 'PARSE_ERROR',
+      errorCode: 'INVALID_INSPECTION_RESULT',
+    })
+  })
+
+  it('turns adapter exceptions and timeouts into FETCH_ERROR', async () => {
+    const failed = await runPublicationInspection(request, {
+      inspectPublication: async () => {
+        throw new Error('secret platform response')
+      },
+    })
+    expect(failed[0]).toMatchObject({
+      outcome: 'FETCH_ERROR',
+      errorCode: 'PUBLICATION_INSPECTION_FAILED',
+      errorMessage: 'The platform inspection failed.',
+    })
+    expect(JSON.stringify(failed)).not.toContain('secret platform response')
+
+    const timedOut = await runPublicationInspection(
+      request,
+      { inspectPublication: () => new Promise(() => {}) },
+      1,
+    )
+    expect(timedOut[0]).toMatchObject({
+      outcome: 'FETCH_ERROR',
+      errorCode: 'PUBLICATION_INSPECTION_TIMEOUT',
+    })
+  })
+})

--- a/packages/extension/__tests__/bridge-legacy-account.test.ts
+++ b/packages/extension/__tests__/bridge-legacy-account.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { projectLegacyAccounts } from '../src/bridge/legacy-account'
+
+describe('projectLegacyAccounts', () => {
+  it('keeps stable identity and authenticated avatar out of the legacy channel', () => {
+    const result = projectLegacyAccounts([
+      {
+        id: 'zhihu',
+        name: 'Zhihu',
+        isAuthenticated: true,
+        username: 'Public display name',
+        userId: 'stable-account-id',
+        icon: 'https://static.example/platform-icon.png',
+        avatar: 'https://private.example/authenticated-avatar.png',
+        homepage: 'https://www.zhihu.com',
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        type: 'zhihu',
+        title: 'Public display name',
+        displayName: 'Zhihu',
+        icon: 'https://static.example/platform-icon.png',
+        avatar: 'https://static.example/platform-icon.png',
+        uid: 'Public display name',
+        home: 'https://www.zhihu.com',
+        supportTypes: ['html'],
+      },
+    ])
+    expect(JSON.stringify(result)).not.toContain('stable-account-id')
+    expect(JSON.stringify(result)).not.toContain('authenticated-avatar')
+  })
+
+  it('ignores logged-out and malformed candidates', () => {
+    expect(
+      projectLegacyAccounts([
+        { id: 'zhihu', isAuthenticated: false },
+        { isAuthenticated: true },
+        null,
+      ]),
+    ).toEqual([])
+  })
+})

--- a/packages/extension/__tests__/bridge-legacy-magic-call.test.ts
+++ b/packages/extension/__tests__/bridge-legacy-magic-call.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  dispatchLegacyMagicCall,
+  LEGACY_MAGIC_CALL_METHOD_NOT_ALLOWED,
+} from '../src/bridge/legacy-magic-call'
+
+describe('dispatchLegacyMagicCall', () => {
+  it.each([
+    'checkAuth',
+    'inspectPublication',
+    'publish',
+    'constructor',
+    '__proto__',
+    'toString',
+  ])('does not dispatch the adapter method %s', async (methodName) => {
+    const checkAuth = vi.fn()
+    const inspectPublication = vi.fn()
+
+    await expect(
+      dispatchLegacyMagicCall(methodName, {
+        account: { type: 'zhihu' },
+        checkAuth,
+        inspectPublication,
+      }),
+    ).resolves.toEqual({ error: LEGACY_MAGIC_CALL_METHOD_NOT_ALLOWED })
+    expect(checkAuth).not.toHaveBeenCalled()
+    expect(inspectPublication).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-string method name', async () => {
+    await expect(dispatchLegacyMagicCall(null, {})).resolves.toEqual({
+      error: LEGACY_MAGIC_CALL_METHOD_NOT_ALLOWED,
+    })
+  })
+})

--- a/packages/extension/__tests__/bridge-protocol.test.ts
+++ b/packages/extension/__tests__/bridge-protocol.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BRIDGE_API_VERSION,
+  BRIDGE_DIRECTIONS,
+  BRIDGE_NAMESPACE,
+  createBridgeErrorResponse,
+  createBridgeSuccessResponse,
+  isAllowedBridgeOrigin,
+  parseBridgeRequestEvent,
+  parseBridgeResponseEvent,
+  type BridgeMessageEventLike,
+} from '../src/bridge'
+
+const topWindow = { kind: 'top-window' }
+
+function requestEvent(
+  overrides: Partial<BridgeMessageEventLike> = {},
+): BridgeMessageEventLike {
+  return {
+    origin: 'http://localhost',
+    source: topWindow,
+    data: {
+      namespace: BRIDGE_NAMESPACE,
+      apiVersion: BRIDGE_API_VERSION,
+      direction: BRIDGE_DIRECTIONS.request,
+      requestId: 'req-001',
+      method: 'getBridgeInfo',
+      payload: {},
+    },
+    ...overrides,
+  }
+}
+
+const inspectPayload = {
+  requestId: 'inspect-001',
+  platform: 'toutiao',
+  externalAccountId: 'account-001',
+  draft: {
+    platformPostId: 'draft-001',
+    draftedAt: '2026-07-21T10:00:00+08:00',
+  },
+  articleHint: {
+    title: 'Phase 0 核验文章',
+    publishedAfter: '2026-07-21T10:00:00+08:00',
+  },
+  limit: 20,
+}
+
+describe('Bridge v2 origin policy', () => {
+  it('only allows exact http://localhost by default', () => {
+    expect(isAllowedBridgeOrigin('http://localhost')).toBe(true)
+    expect(isAllowedBridgeOrigin('http://localhost:80')).toBe(false)
+    expect(isAllowedBridgeOrigin('http://localhost:3000')).toBe(false)
+    expect(isAllowedBridgeOrigin('http://127.0.0.1')).toBe(false)
+    expect(isAllowedBridgeOrigin('https://localhost')).toBe(false)
+    expect(isAllowedBridgeOrigin('http://localhost.evil.example')).toBe(false)
+    expect(isAllowedBridgeOrigin('null')).toBe(false)
+  })
+
+  it('never interprets wildcard entries as an allow rule', () => {
+    expect(isAllowedBridgeOrigin('https://evil.example', ['*'])).toBe(false)
+    expect(
+      isAllowedBridgeOrigin('https://evil.example', ['https://*.example']),
+    ).toBe(false)
+  })
+
+  it('supports future exact non-loopback build origins without prefix matching', () => {
+    const allowlist = ['https://staging.vibemarket.example']
+    expect(
+      isAllowedBridgeOrigin('https://staging.vibemarket.example', allowlist),
+    ).toBe(true)
+    expect(
+      isAllowedBridgeOrigin(
+        'https://staging.vibemarket.example.evil',
+        allowlist,
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('Bridge v2 request parsing', () => {
+  it('accepts the three allowlisted methods with validated payloads', () => {
+    const bridgeInfo = parseBridgeRequestEvent(requestEvent(), topWindow)
+    expect(bridgeInfo.success).toBe(true)
+
+    const accounts = parseBridgeRequestEvent(
+      requestEvent({
+        data: {
+          namespace: BRIDGE_NAMESPACE,
+          apiVersion: BRIDGE_API_VERSION,
+          direction: BRIDGE_DIRECTIONS.request,
+          requestId: 'accounts-001',
+          method: 'getAccountsV2',
+          payload: {
+            platforms: ['toutiao', 'zhihu', 'sohu', 'weixin'],
+            forceRefresh: true,
+          },
+        },
+      }),
+      topWindow,
+    )
+    expect(accounts).toMatchObject({
+      success: true,
+      data: { method: 'getAccountsV2' },
+    })
+
+    const inspect = parseBridgeRequestEvent(
+      requestEvent({
+        data: {
+          namespace: BRIDGE_NAMESPACE,
+          apiVersion: BRIDGE_API_VERSION,
+          direction: BRIDGE_DIRECTIONS.request,
+          requestId: 'inspect-001',
+          method: 'inspectPublication',
+          payload: inspectPayload,
+        },
+      }),
+      topWindow,
+    )
+    expect(inspect).toMatchObject({
+      success: true,
+      data: { method: 'inspectPublication', payload: inspectPayload },
+    })
+  })
+
+  it.each([
+    'https://evil.example',
+    'http://localhost:3000',
+    'http://127.0.0.1',
+    'http://localhost.evil.example',
+  ])('rejects malicious or unlisted origin %s', (origin) => {
+    expect(
+      parseBridgeRequestEvent(requestEvent({ origin }), topWindow),
+    ).toEqual({ success: false, code: 'ORIGIN_NOT_ALLOWED' })
+  })
+
+  it('rejects a message from a child or foreign frame', () => {
+    expect(
+      parseBridgeRequestEvent(
+        requestEvent({ source: { kind: 'child-frame' } }),
+        topWindow,
+      ),
+    ).toEqual({ success: false, code: 'SOURCE_MISMATCH' })
+  })
+
+  it('rejects unknown methods before touching their payload', () => {
+    const event = requestEvent()
+    ;(event.data as Record<string, unknown>).method = 'magicCall'
+    ;(event.data as Record<string, unknown>).payload = { arbitrary: true }
+
+    expect(parseBridgeRequestEvent(event, topWindow)).toEqual({
+      success: false,
+      code: 'METHOD_NOT_ALLOWED',
+    })
+  })
+
+  it.each([
+    null,
+    [],
+    { namespace: BRIDGE_NAMESPACE },
+    {
+      namespace: BRIDGE_NAMESPACE,
+      apiVersion: BRIDGE_API_VERSION,
+      direction: BRIDGE_DIRECTIONS.request,
+      requestId: '',
+      method: 'getBridgeInfo',
+      payload: {},
+    },
+    {
+      namespace: BRIDGE_NAMESPACE,
+      apiVersion: BRIDGE_API_VERSION,
+      direction: BRIDGE_DIRECTIONS.response,
+      requestId: 'req-001',
+      method: 'getBridgeInfo',
+      payload: {},
+    },
+  ])('rejects malformed envelopes', (data) => {
+    expect(parseBridgeRequestEvent(requestEvent({ data }), topWindow)).toEqual({
+      success: false,
+      code: 'INVALID_ENVELOPE',
+    })
+  })
+
+  it('normalizes request IDs before enforcing the 128-character limit', () => {
+    const requestId = 'r'.repeat(128)
+    const accepted = requestEvent()
+    accepted.data = {
+      ...(accepted.data as Record<string, unknown>),
+      requestId: ` ${requestId} `,
+    }
+
+    expect(parseBridgeRequestEvent(accepted, topWindow)).toMatchObject({
+      success: true,
+      data: { requestId },
+    })
+
+    const rejected = requestEvent()
+    rejected.data = {
+      ...(rejected.data as Record<string, unknown>),
+      requestId: `${requestId}x`,
+    }
+    expect(parseBridgeRequestEvent(rejected, topWindow)).toEqual({
+      success: false,
+      code: 'INVALID_ENVELOPE',
+    })
+  })
+
+  it('binds inspection payloads to the normalized envelope request ID', () => {
+    const paddedRequestId = ' inspect-001 '
+    const event = requestEvent()
+    event.data = {
+      ...(event.data as Record<string, unknown>),
+      requestId: paddedRequestId,
+      method: 'inspectPublication',
+      payload: { ...inspectPayload, requestId: paddedRequestId },
+    }
+
+    expect(parseBridgeRequestEvent(event, topWindow)).toMatchObject({
+      success: true,
+      data: {
+        requestId: 'inspect-001',
+        payload: { requestId: 'inspect-001' },
+      },
+    })
+  })
+
+  it('rejects malformed and over-broad account payloads', () => {
+    const duplicatePlatforms = requestEvent()
+    duplicatePlatforms.data = {
+      ...(duplicatePlatforms.data as Record<string, unknown>),
+      requestId: 'accounts-001',
+      method: 'getAccountsV2',
+      payload: { platforms: ['toutiao', 'toutiao'] },
+    }
+
+    expect(parseBridgeRequestEvent(duplicatePlatforms, topWindow)).toEqual({
+      success: false,
+      code: 'INVALID_PAYLOAD',
+    })
+
+    const unknownKey = requestEvent()
+    unknownKey.data = {
+      ...(unknownKey.data as Record<string, unknown>),
+      requestId: 'accounts-002',
+      method: 'getAccountsV2',
+      payload: { forceRefresh: false, unsafe: true },
+    }
+
+    expect(parseBridgeRequestEvent(unknownKey, topWindow)).toEqual({
+      success: false,
+      code: 'INVALID_PAYLOAD',
+    })
+  })
+
+  it('rejects malformed inspection payloads and mismatched request IDs', () => {
+    const mismatch = requestEvent()
+    mismatch.data = {
+      ...(mismatch.data as Record<string, unknown>),
+      requestId: 'envelope-id',
+      method: 'inspectPublication',
+      payload: inspectPayload,
+    }
+    expect(parseBridgeRequestEvent(mismatch, topWindow)).toEqual({
+      success: false,
+      code: 'INVALID_PAYLOAD',
+    })
+
+    const excessiveLimit = requestEvent()
+    excessiveLimit.data = {
+      ...(excessiveLimit.data as Record<string, unknown>),
+      requestId: 'inspect-001',
+      method: 'inspectPublication',
+      payload: { ...inspectPayload, limit: 21 },
+    }
+    expect(parseBridgeRequestEvent(excessiveLimit, topWindow)).toEqual({
+      success: false,
+      code: 'INVALID_PAYLOAD',
+    })
+  })
+})
+
+describe('Bridge v2 responses', () => {
+  it('creates and parses a schema-validated success response', () => {
+    const parsedRequest = parseBridgeRequestEvent(requestEvent(), topWindow)
+    if (
+      !parsedRequest.success ||
+      parsedRequest.data.method !== 'getBridgeInfo'
+    ) {
+      throw new Error('expected a getBridgeInfo request')
+    }
+
+    const response = createBridgeSuccessResponse(parsedRequest.data, {
+      apiVersion: '2.0',
+      extensionVersion: '2.0.10',
+      capabilities: ['account_identity', 'publication_inspect', 'public_url'],
+    })
+
+    expect(
+      parseBridgeResponseEvent(
+        { origin: 'http://localhost', source: topWindow, data: response },
+        topWindow,
+      ),
+    ).toEqual({ success: true, data: response })
+  })
+
+  it('creates and parses a bounded error response', () => {
+    const parsedRequest = parseBridgeRequestEvent(requestEvent(), topWindow)
+    if (
+      !parsedRequest.success ||
+      parsedRequest.data.method !== 'getBridgeInfo'
+    ) {
+      throw new Error('expected a getBridgeInfo request')
+    }
+
+    const response = createBridgeErrorResponse(parsedRequest.data, {
+      code: 'LOGIN_REQUIRED',
+      message: 'Please log in first',
+    })
+
+    expect(
+      parseBridgeResponseEvent(
+        { origin: 'http://localhost', source: topWindow, data: response },
+        topWindow,
+      ),
+    ).toEqual({ success: true, data: response })
+  })
+
+  it('rejects malformed response results', () => {
+    const malformed = {
+      namespace: BRIDGE_NAMESPACE,
+      apiVersion: BRIDGE_API_VERSION,
+      direction: BRIDGE_DIRECTIONS.response,
+      requestId: 'req-001',
+      method: 'getBridgeInfo',
+      ok: true,
+      result: { apiVersion: '1.0' },
+    }
+
+    expect(
+      parseBridgeResponseEvent(
+        { origin: 'http://localhost', source: topWindow, data: malformed },
+        topWindow,
+      ),
+    ).toEqual({ success: false, code: 'INVALID_PAYLOAD' })
+  })
+})

--- a/packages/extension/__tests__/bridge-sync-result.test.ts
+++ b/packages/extension/__tests__/bridge-sync-result.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { toLegacyEditResponse } from '../src/bridge/sync-result'
+
+describe('toLegacyEditResponse', () => {
+  it('keeps the WeChat post ID without exposing its token URL', () => {
+    const result = toLegacyEditResponse({
+      platform: 'weixin',
+      success: true,
+      postId: '9001',
+      postUrl:
+        'https://mp.weixin.qq.com/cgi-bin/appmsg?appmsgid=9001&token=secret',
+    })
+
+    expect(result).toEqual({ postId: '9001' })
+    expect(JSON.stringify(result)).not.toContain('secret')
+  })
+
+  it('sanitizes another platform URL and preserves its post ID', () => {
+    expect(
+      toLegacyEditResponse({
+        platform: 'zhihu',
+        success: true,
+        postId: '42',
+        postUrl:
+          'https://zhuanlan.zhihu.com/p/42/edit?token=secret&source=sync#draft',
+      }),
+    ).toEqual({
+      draftLink: 'https://zhuanlan.zhihu.com/p/42/edit?source=sync',
+      postId: '42',
+    })
+  })
+
+  it('returns null for failures and rejects malformed post IDs', () => {
+    expect(toLegacyEditResponse({ success: false, postId: '42' })).toBeNull()
+    expect(
+      toLegacyEditResponse({
+        platform: 'sohu',
+        success: true,
+        postId: 'x'.repeat(501),
+      }),
+    ).toEqual({})
+  })
+})

--- a/packages/extension/__tests__/runtime-fetch-credentials.test.ts
+++ b/packages/extension/__tests__/runtime-fetch-credentials.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ExtensionRuntime } from '../src/runtime/extension'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('ExtensionRuntime.fetch credentials', () => {
+  it('preserves an explicit anonymous request', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await new ExtensionRuntime().fetch('https://example.com/public', {
+      credentials: 'omit',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/public',
+      expect.objectContaining({ credentials: 'omit' }),
+    )
+  })
+
+  it('defaults to authenticated requests when credentials are absent', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await new ExtensionRuntime().fetch('https://example.com/account')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/account',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+  })
+
+  it('keeps an explicit authenticated draft request', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await new ExtensionRuntime().fetch('https://example.com/draft', {
+      credentials: 'include',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/draft',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+  })
+})

--- a/packages/extension/__tests__/zhihu-runtime-integration.test.ts
+++ b/packages/extension/__tests__/zhihu-runtime-integration.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ZhihuAdapter } from '../../core/src/adapters/platforms/zhihu'
+import type { PublicationInspectRequest } from '@wechatsync/core/publication-inspection'
+import { ExtensionRuntime } from '../src/runtime/extension'
+
+const POST_ID = '2000000000000000001'
+const ACCOUNT_ID = 'account-zhihu'
+const PUBLIC_URL = `https://zhuanlan.zhihu.com/p/${POST_ID}`
+const DRAFT_API_URL = `https://zhuanlan.zhihu.com/api/articles/${POST_ID}/draft`
+
+const request: PublicationInspectRequest = {
+  requestId: 'runtime-integration-1',
+  platform: 'zhihu',
+  externalAccountId: ACCOUNT_ID,
+  draft: {
+    platformPostId: POST_ID,
+    draftUrl: `${PUBLIC_URL}/edit`,
+    draftedAt: '2026-07-21T10:00:00+08:00',
+  },
+  articleHint: { title: 'A trusted publication sample' },
+  limit: 20,
+}
+
+const publishedHtml = `
+  <html>
+    <head>
+      <link href="${PUBLIC_URL}" rel="canonical">
+      <meta content="${PUBLIC_URL}" property="og:url">
+      <script type="text/json" id="js-initialData">${JSON.stringify({
+        initialState: {
+          entities: {
+            articles: {
+              [POST_ID]: {
+                id: POST_ID,
+                type: 'article',
+                articleType: 'normal',
+                author: { id: ACCOUNT_ID },
+                state: 'published',
+                status: 0,
+                isVisible: true,
+                isNormal: true,
+                url: PUBLIC_URL,
+                created: 1_784_706_540,
+                title: 'A trusted publication sample',
+                content: '<p>Published body</p>',
+              },
+            },
+          },
+        },
+      })}</script>
+    </head>
+    <body><article><p>Published body</p></article></body>
+  </html>
+`
+
+function jsonResponse(url: string, payload: unknown, status = 200): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    url,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  } as Response
+}
+
+function htmlResponse(url: string, body: string, status = 200): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    url,
+    headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+    text: async () => body,
+  } as Response
+}
+
+async function inspectWith(fetchMock: ReturnType<typeof vi.fn>) {
+  vi.stubGlobal('fetch', fetchMock)
+  const adapter = new ZhihuAdapter()
+  await adapter.init(new ExtensionRuntime())
+  return adapter.inspectPublication(request)
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('ZhihuAdapter with ExtensionRuntime', () => {
+  it('uses authentication for identity but anonymous credentials for public evidence', async () => {
+    const fetchMock = vi.fn(async (url: string, options?: RequestInit) => {
+      if (url === 'https://www.zhihu.com/api/v4/me') {
+        return jsonResponse(url, { id: ACCOUNT_ID, name: 'Zhihu Creator' })
+      }
+      if (url === PUBLIC_URL) return htmlResponse(url, publishedHtml)
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    const observations = await inspectWith(fetchMock)
+
+    expect(observations).toHaveLength(1)
+    expect(observations[0]).toMatchObject({
+      outcome: 'PUBLISHED',
+      platformPostId: POST_ID,
+      canonicalUrl: PUBLIC_URL,
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://www.zhihu.com/api/v4/me',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      PUBLIC_URL,
+      expect.objectContaining({ credentials: 'omit' }),
+    )
+  })
+
+  it('does not classify an owner-only page as publicly published', async () => {
+    const fetchMock = vi.fn(async (url: string, options?: RequestInit) => {
+      if (url === 'https://www.zhihu.com/api/v4/me') {
+        return jsonResponse(url, { id: ACCOUNT_ID, name: 'Zhihu Creator' })
+      }
+      if (url === PUBLIC_URL) {
+        return options?.credentials === 'include'
+          ? htmlResponse(url, publishedHtml)
+          : htmlResponse(url, '', 404)
+      }
+      if (url === DRAFT_API_URL) return jsonResponse(url, {}, 404)
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    const observations = await inspectWith(fetchMock)
+
+    expect(observations).toHaveLength(1)
+    expect(observations[0].outcome).not.toBe('PUBLISHED')
+    expect(fetchMock).toHaveBeenCalledWith(
+      PUBLIC_URL,
+      expect.objectContaining({ credentials: 'omit' }),
+    )
+  })
+})

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "文章同步助手",
   "description": "一键同步文章到知乎、头条、掘金等 20+ 平台，支持 WordPress 等自建站",
-  "version": "2.0.9",
+  "version": "2.0.15",
   "icons": {
     "16": "assets/icon-16.png",
     "48": "assets/icon-48.png",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@wechatsync/extension",
-  "version": "2.0.9",
+  "version": "2.0.15",
   "private": true,
   "description": "微信公众号同步助手 Chrome 扩展",
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc --noEmit && vite build",
     "prod": "npm run build && cd dist && zip -r ../wechatsync-v$(node -p \"require('../package.json').version\").zip .",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",

--- a/packages/extension/public/inject-api.js
+++ b/packages/extension/public/inject-api.js
@@ -1,12 +1,18 @@
 (function() {
   console.log('api ready');
 
+  var BRIDGE_NAMESPACE = 'vibemarket.syncer.bridge';
+  var BRIDGE_API_VERSION = '2.0';
+  var BRIDGE_REQUEST_DIRECTION = 'PAGE_TO_EXTENSION';
+  var BRIDGE_RESPONSE_DIRECTION = 'EXTENSION_TO_PAGE';
+
   var poster = {
     versionNumber: 1001,
     dev: location.hostname === 'localhost' || location.hostname === '127.0.0.1',
   };
 
   var eventCb = {};
+  var bridgeEventCb = {};
   var _statueandler = null;
   var _consolehandler = null;
 
@@ -18,12 +24,57 @@
     window.postMessage(JSON.stringify(msg), '*');
   }
 
+  function createBridgeRequestId() {
+    return 'bridge_' + Date.now() + '_' + Math.random().toString(36).slice(2, 11);
+  }
+
+  function callBridge(method, payload, cb, requestId) {
+    var id = requestId || createBridgeRequestId();
+    bridgeEventCb[id] = {
+      method: method,
+      callback: typeof cb === 'function' ? cb : function() {},
+    };
+
+    window.postMessage(
+      {
+        namespace: BRIDGE_NAMESPACE,
+        apiVersion: BRIDGE_API_VERSION,
+        direction: BRIDGE_REQUEST_DIRECTION,
+        requestId: id,
+        method: method,
+        payload: payload || {},
+      },
+      location.origin
+    );
+  }
+
   poster.getAccounts = function(cb) {
     callFunc(
       {
         method: 'getAccounts',
       },
       cb
+    );
+  };
+
+  poster.getBridgeInfo = function(cb) {
+    callBridge('getBridgeInfo', {}, cb);
+  };
+
+  poster.getAccountsV2 = function(options, cb) {
+    if (typeof options === 'function') {
+      cb = options;
+      options = {};
+    }
+    callBridge('getAccountsV2', options || {}, cb);
+  };
+
+  poster.inspectPublication = function(request, cb) {
+    callBridge(
+      'inspectPublication',
+      request,
+      cb,
+      request && request.requestId
     );
   };
 
@@ -82,6 +133,30 @@
 
   window.addEventListener('message', function(evt) {
     try {
+      if (
+        evt.source === window &&
+        evt.origin === location.origin &&
+        evt.data &&
+        typeof evt.data === 'object' &&
+        evt.data.namespace === BRIDGE_NAMESPACE &&
+        evt.data.apiVersion === BRIDGE_API_VERSION &&
+        evt.data.direction === BRIDGE_RESPONSE_DIRECTION
+      ) {
+        var bridgeCallback = bridgeEventCb[evt.data.requestId];
+        if (!bridgeCallback || bridgeCallback.method !== evt.data.method) return;
+
+        if (evt.data.ok) {
+          bridgeCallback.callback(null, evt.data.result);
+        } else {
+          bridgeCallback.callback(evt.data.error || {
+            code: 'UNKNOWN_ERROR',
+            message: 'Bridge request failed',
+          });
+        }
+        delete bridgeEventCb[evt.data.requestId];
+        return;
+      }
+
       var action = JSON.parse(evt.data);
       if (action.method && action.method === 'taskUpdate') {
         if (_statueandler != null) _statueandler(action.task);

--- a/packages/extension/src/adapters/index.ts
+++ b/packages/extension/src/adapters/index.ts
@@ -5,6 +5,7 @@ import {
   adapterRegistry,
   type PlatformAdapter,
   type PlatformMeta,
+  type AuthResult,
   type Article,
   type SyncResult,
 } from '@wechatsync/core'
@@ -223,10 +224,7 @@ export async function checkPlatformAuth(platformId: string) {
   }
 }
 
-interface AuthCacheItem {
-  isAuthenticated: boolean
-  username?: string
-  error?: string
+interface AuthCacheItem extends AuthResult {
   timestamp: number
 }
 
@@ -263,13 +261,21 @@ export async function clearAuthCache(): Promise<void> {
 /**
  * 检查所有平台登录状态（带缓存，并行检查）
  */
-export async function checkAllPlatformsAuth(forceRefresh = false) {
+export async function checkAllPlatformsAuth(
+  forceRefresh = false,
+  targetPlatformIds?: readonly string[],
+) {
   await initAdapters()
 
-  const metas = adapterRegistry.getAllMeta()
+  const targetPlatforms = targetPlatformIds
+    ? new Set(targetPlatformIds)
+    : null
+  const metas = adapterRegistry
+    .getAllMeta()
+    .filter(meta => !targetPlatforms || targetPlatforms.has(meta.id))
   const cache = await getCachedAuth()
   const now = Date.now()
-  const results: Array<PlatformMeta & { isAuthenticated: boolean; username?: string; error?: string }> = []
+  const results: Array<PlatformMeta & AuthResult> = []
   const needsCheck: PlatformMeta[] = [] // 需要实际检查的平台
 
   logger.debug(' Checking auth for platforms:', metas.map(m => m.id), forceRefresh ? '(force refresh)' : '')
@@ -286,6 +292,8 @@ export async function checkAllPlatformsAuth(forceRefresh = false) {
         ...meta,
         isAuthenticated: cached.isAuthenticated,
         username: cached.username,
+        userId: cached.userId,
+        avatar: cached.avatar,
         error: cached.error,
       })
     } else {
@@ -318,6 +326,8 @@ export async function checkAllPlatformsAuth(forceRefresh = false) {
             cache[meta.id] = {
               isAuthenticated: auth.isAuthenticated,
               username: auth.username,
+              userId: auth.userId,
+              avatar: auth.avatar,
               error: auth.error,
               timestamp: now,
             }
@@ -326,6 +336,8 @@ export async function checkAllPlatformsAuth(forceRefresh = false) {
               ...meta,
               isAuthenticated: auth.isAuthenticated,
               username: auth.username,
+              userId: auth.userId,
+              avatar: auth.avatar,
               error: auth.error,
             }
           }

--- a/packages/extension/src/background/bridge-v2.ts
+++ b/packages/extension/src/background/bridge-v2.ts
@@ -1,0 +1,510 @@
+import {
+  parsePublicationUrl,
+  PublicationInspectRequestSchema,
+  PublicationObservationSchema,
+  PublicationPlatformSchema,
+  SyncerAccountV2Schema,
+  ZHIHU_ARTICLE_SUCCESS_OUTCOMES,
+  type PublicationInspectRequest,
+  type PublicationObservation,
+  type PublicationPlatform,
+  type SyncerAccountV2,
+} from '@wechatsync/core/publication-inspection'
+import type { PlatformAdapter } from '@wechatsync/core'
+
+import {
+  DEFAULT_BRIDGE_ALLOWED_ORIGINS,
+  normalizeBridgeRequestId,
+  type GetAccountsV2Payload,
+} from '../bridge/protocol'
+
+const BRIDGE_ORIGIN = DEFAULT_BRIDGE_ALLOWED_ORIGINS[0]
+const ACCOUNT_CAPABILITIES = {
+  toutiao: ['account_identity'],
+  zhihu: ['account_identity', 'publication_inspect', 'public_url'],
+  sohu: ['account_identity'],
+  weixin: ['account_identity'],
+} as const satisfies Record<
+  PublicationPlatform,
+  readonly SyncerAccountV2['capabilities'][number][]
+>
+const INSPECTION_TIMEOUT_MS = 12_000
+const ACTIVE_INSPECTION_PLATFORMS = new Set<PublicationPlatform>(['zhihu'])
+const GET_ACCOUNTS_KEYS = new Set(['platforms', 'forceRefresh'])
+const INSPECT_KEYS = new Set([
+  'requestId',
+  'platform',
+  'externalAccountId',
+  'draft',
+  'articleHint',
+  'limit',
+])
+const INSPECT_DRAFT_KEYS = new Set(['platformPostId', 'draftUrl', 'draftedAt'])
+const INSPECT_ARTICLE_HINT_KEYS = new Set([
+  'title',
+  'publishedAfter',
+  'publishedBefore',
+])
+
+export type BackgroundBridgeFailureCode =
+  | 'SENDER_NOT_ALLOWED'
+  | 'INVALID_PAYLOAD'
+
+export type BackgroundBridgeValidationResult<T> =
+  | { success: true; data: T }
+  | { success: false; code: BackgroundBridgeFailureCode }
+
+export interface VerifiedBridgeMessageSender {
+  origin: typeof BRIDGE_ORIGIN
+  tabId: number
+  url: string
+}
+
+/**
+ * Minimal shape returned by checkAllPlatformsAuth. Keeping this boundary typed
+ * as unknown prevents legacy adapter fields from crossing Bridge v2 by accident.
+ */
+export interface AuthenticatedPlatformCandidate {
+  id?: unknown
+  name?: unknown
+  homepage?: unknown
+  isAuthenticated?: unknown
+  username?: unknown
+  userId?: unknown
+  avatar?: unknown
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  allowedKeys: ReadonlySet<string>,
+): boolean {
+  return (
+    Object.getOwnPropertySymbols(value).length === 0 &&
+    Object.keys(value).every((key) => allowedKeys.has(key))
+  )
+}
+
+function isExactBridgePageUrl(value: unknown): value is string {
+  if (typeof value !== 'string') return false
+
+  try {
+    const parsed = new URL(value)
+    return (
+      parsed.origin === BRIDGE_ORIGIN &&
+      parsed.protocol === 'http:' &&
+      parsed.hostname === 'localhost' &&
+      parsed.port === '' &&
+      parsed.username === '' &&
+      parsed.password === ''
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Accept Bridge v2 messages only from the top frame of the canonical local app.
+ * Chrome's MessageSender is treated as the authority; page-provided message
+ * fields are deliberately not consulted here.
+ */
+export function validateBridgeMessageSender(
+  sender: chrome.runtime.MessageSender,
+): BackgroundBridgeValidationResult<VerifiedBridgeMessageSender> {
+  const tabId = sender.tab?.id
+  if (
+    !Number.isInteger(tabId) ||
+    (tabId as number) < 0 ||
+    sender.frameId !== 0 ||
+    sender.origin !== BRIDGE_ORIGIN ||
+    !isExactBridgePageUrl(sender.url) ||
+    !isExactBridgePageUrl(sender.tab?.url)
+  ) {
+    return { success: false, code: 'SENDER_NOT_ALLOWED' }
+  }
+
+  return {
+    success: true,
+    data: {
+      origin: BRIDGE_ORIGIN,
+      tabId: tabId as number,
+      url: sender.url,
+    },
+  }
+}
+
+function parsePlatformList(value: unknown): PublicationPlatform[] | null {
+  if (!Array.isArray(value) || value.length > 4) return null
+
+  const platforms: PublicationPlatform[] = []
+  for (const candidate of value) {
+    const parsed = PublicationPlatformSchema.safeParse(candidate)
+    if (!parsed.success || platforms.includes(parsed.data)) return null
+    platforms.push(parsed.data)
+  }
+
+  return platforms
+}
+
+/** Revalidates the page payload at the background trust boundary. */
+export function validateGetAccountsV2Payload(
+  payload: unknown,
+): BackgroundBridgeValidationResult<GetAccountsV2Payload> {
+  if (!isRecord(payload) || !hasOnlyKeys(payload, GET_ACCOUNTS_KEYS)) {
+    return { success: false, code: 'INVALID_PAYLOAD' }
+  }
+
+  if (
+    typeof payload.forceRefresh !== 'undefined' &&
+    typeof payload.forceRefresh !== 'boolean'
+  ) {
+    return { success: false, code: 'INVALID_PAYLOAD' }
+  }
+
+  let platforms: PublicationPlatform[] | undefined
+  if (typeof payload.platforms !== 'undefined') {
+    const parsedPlatforms = parsePlatformList(payload.platforms)
+    if (parsedPlatforms === null) {
+      return { success: false, code: 'INVALID_PAYLOAD' }
+    }
+    platforms = parsedPlatforms
+  }
+
+  return {
+    success: true,
+    data: {
+      ...(platforms ? { platforms } : {}),
+      ...(typeof payload.forceRefresh === 'boolean'
+        ? { forceRefresh: payload.forceRefresh }
+        : {}),
+    },
+  }
+}
+
+function hasStrictInspectShape(
+  value: unknown,
+): value is Record<string, unknown> {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, INSPECT_KEYS) &&
+    isRecord(value.draft) &&
+    hasOnlyKeys(value.draft, INSPECT_DRAFT_KEYS) &&
+    isRecord(value.articleHint) &&
+    hasOnlyKeys(value.articleHint, INSPECT_ARTICLE_HINT_KEYS)
+  )
+}
+
+/** Revalidates inspectPublication after the content-script protocol parser. */
+export function validateInspectPublicationPayload(
+  payload: unknown,
+  envelopeRequestId: string,
+): BackgroundBridgeValidationResult<PublicationInspectRequest> {
+  if (!hasStrictInspectShape(payload)) {
+    return { success: false, code: 'INVALID_PAYLOAD' }
+  }
+
+  const parsed = PublicationInspectRequestSchema.safeParse(payload)
+  const normalizedEnvelopeRequestId =
+    normalizeBridgeRequestId(envelopeRequestId)
+  if (
+    !parsed.success ||
+    normalizedEnvelopeRequestId === null ||
+    parsed.data.requestId !== normalizedEnvelopeRequestId
+  ) {
+    return { success: false, code: 'INVALID_PAYLOAD' }
+  }
+
+  return { success: true, data: parsed.data }
+}
+
+function safeHttpUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+
+  try {
+    const parsed = new URL(value)
+    if (
+      (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') ||
+      parsed.username !== '' ||
+      parsed.password !== ''
+    ) {
+      return undefined
+    }
+    return parsed.href
+  } catch {
+    return undefined
+  }
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : undefined
+}
+
+/**
+ * Converts legacy auth results into the intentionally narrow Bridge v2 account
+ * representation. At most one account is emitted per Phase 0 platform.
+ */
+export function buildSyncerAccountsV2(
+  candidates: readonly AuthenticatedPlatformCandidate[],
+  requestedPlatforms?: readonly PublicationPlatform[],
+): SyncerAccountV2[] {
+  const requested = requestedPlatforms
+    ? new Set<PublicationPlatform>(requestedPlatforms)
+    : null
+  const emitted = new Set<PublicationPlatform>()
+  const accounts: SyncerAccountV2[] = []
+
+  for (const candidate of candidates) {
+    const platform = PublicationPlatformSchema.safeParse(candidate.id)
+    if (
+      !platform.success ||
+      candidate.isAuthenticated !== true ||
+      (requested && !requested.has(platform.data)) ||
+      emitted.has(platform.data)
+    ) {
+      continue
+    }
+
+    const externalAccountId = nonEmptyString(candidate.userId)
+    if (!externalAccountId) continue
+
+    const account = SyncerAccountV2Schema.safeParse({
+      platform: platform.data,
+      externalAccountId,
+      displayName:
+        nonEmptyString(candidate.username) ??
+        nonEmptyString(candidate.name) ??
+        externalAccountId,
+      ...(safeHttpUrl(candidate.avatar)
+        ? { avatarUrl: safeHttpUrl(candidate.avatar) }
+        : {}),
+      ...(safeHttpUrl(candidate.homepage)
+        ? { homepage: safeHttpUrl(candidate.homepage) }
+        : {}),
+      capabilities: [...ACCOUNT_CAPABILITIES[platform.data]],
+    })
+
+    if (!account.success) continue
+    accounts.push(account.data)
+    emitted.add(platform.data)
+  }
+
+  return accounts
+}
+
+/**
+ * Paused platforms remain callable at the protocol level but explicitly return
+ * UNSUPPORTED. This avoids misclassifying absence as NOT_FOUND.
+ */
+export function createUnsupportedPublicationObservation(
+  request: PublicationInspectRequest,
+  observedAt = new Date().toISOString(),
+): PublicationObservation {
+  return PublicationObservationSchema.parse({
+    observationKey: `bridge-v2:${request.requestId}:${request.platform}:unsupported`,
+    platform: request.platform,
+    externalAccountId: request.externalAccountId,
+    outcome: 'UNSUPPORTED',
+    source: 'PLATFORM_DETAIL',
+    observedAt,
+    errorCode: 'PUBLICATION_INSPECTION_NOT_IMPLEMENTED',
+    errorMessage: `Publication inspection is not implemented for ${request.platform} in Phase 0.`,
+  })
+}
+
+type PublicationInspectorAdapter = Pick<PlatformAdapter, 'inspectPublication'>
+
+function resolveZhihuRequestPostId(
+  request: PublicationInspectRequest,
+): string | null {
+  const explicitPostId = request.draft.platformPostId
+  let draftUrlPostId: string | undefined
+
+  if (request.draft.draftUrl) {
+    const parsedDraftUrl = parsePublicationUrl('zhihu', request.draft.draftUrl)
+    if (
+      !parsedDraftUrl ||
+      parsedDraftUrl.surface !== 'DRAFT' ||
+      !parsedDraftUrl.postId
+    ) {
+      return null
+    }
+    draftUrlPostId = parsedDraftUrl.postId
+  }
+
+  if (explicitPostId && draftUrlPostId && explicitPostId !== draftUrlPostId) {
+    return null
+  }
+
+  return explicitPostId ?? draftUrlPostId ?? null
+}
+
+function createInspectionFailure(
+  request: PublicationInspectRequest,
+  outcome: 'FETCH_ERROR' | 'PARSE_ERROR',
+  errorCode: string,
+  errorMessage: string,
+  observedAt = new Date().toISOString(),
+): PublicationObservation {
+  return PublicationObservationSchema.parse({
+    observationKey: `bridge-v2:${request.requestId}:${request.platform}:${errorCode.toLowerCase()}`,
+    platform: request.platform,
+    externalAccountId: request.externalAccountId,
+    outcome,
+    source: 'PLATFORM_DETAIL',
+    observedAt,
+    errorCode,
+    errorMessage,
+  })
+}
+
+function normalizeAdapterObservations(
+  request: PublicationInspectRequest,
+  value: unknown,
+): PublicationObservation[] | null {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.length > request.limit
+  ) {
+    return null
+  }
+
+  const seenKeys = new Set<string>()
+  const observations: PublicationObservation[] = []
+  for (const candidate of value) {
+    const parsed = PublicationObservationSchema.safeParse(candidate)
+    if (
+      !parsed.success ||
+      parsed.data.platform !== request.platform ||
+      parsed.data.externalAccountId !== request.externalAccountId ||
+      seenKeys.has(parsed.data.observationKey)
+    ) {
+      return null
+    }
+
+    let normalized = parsed.data
+    const expectedZhihuPostId =
+      request.platform === 'zhihu' ? resolveZhihuRequestPostId(request) : null
+    if (
+      request.platform === 'zhihu' &&
+      ZHIHU_ARTICLE_SUCCESS_OUTCOMES.includes(normalized.outcome) &&
+      (!expectedZhihuPostId ||
+        normalized.platformPostId !== expectedZhihuPostId)
+    ) {
+      return null
+    }
+
+    if (normalized.canonicalUrl) {
+      const canonical = parsePublicationUrl(
+        request.platform,
+        normalized.canonicalUrl,
+      )
+      if (
+        !canonical ||
+        canonical.surface !== 'PUBLISHED' ||
+        !canonical.canonicalUrl
+      ) {
+        return null
+      }
+      if (
+        request.platform === 'zhihu' &&
+        ZHIHU_ARTICLE_SUCCESS_OUTCOMES.includes(normalized.outcome) &&
+        (!expectedZhihuPostId ||
+          canonical.postId !== expectedZhihuPostId ||
+          canonical.postId !== normalized.platformPostId)
+      ) {
+        return null
+      }
+      normalized = {
+        ...normalized,
+        canonicalUrl: canonical.canonicalUrl,
+      }
+    }
+
+    seenKeys.add(normalized.observationKey)
+    observations.push(normalized)
+  }
+
+  return observations
+}
+
+function withInspectionTimeout<T>(promise: Promise<T>, timeoutMs: number) {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('PUBLICATION_INSPECTION_TIMEOUT')),
+      timeoutMs,
+    )
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      },
+    )
+  })
+}
+
+/**
+ * Execute an adapter inspector behind a final schema, account, URL and timeout
+ * boundary. Adapter failures never become NOT_FOUND.
+ */
+export async function runPublicationInspection(
+  request: PublicationInspectRequest,
+  adapter: PublicationInspectorAdapter | null,
+  timeoutMs = INSPECTION_TIMEOUT_MS,
+): Promise<PublicationObservation[]> {
+  if (
+    !ACTIVE_INSPECTION_PLATFORMS.has(request.platform) ||
+    !adapter?.inspectPublication
+  ) {
+    return [createUnsupportedPublicationObservation(request)]
+  }
+
+  try {
+    const value = await withInspectionTimeout(
+      adapter.inspectPublication(request),
+      timeoutMs,
+    )
+    const observations = normalizeAdapterObservations(request, value)
+    if (!observations) {
+      return [
+        createInspectionFailure(
+          request,
+          'PARSE_ERROR',
+          'INVALID_INSPECTION_RESULT',
+          'The platform inspector returned an invalid result.',
+        ),
+      ]
+    }
+    return observations
+  } catch (error) {
+    const timedOut =
+      error instanceof Error &&
+      error.message === 'PUBLICATION_INSPECTION_TIMEOUT'
+    return [
+      createInspectionFailure(
+        request,
+        'FETCH_ERROR',
+        timedOut
+          ? 'PUBLICATION_INSPECTION_TIMEOUT'
+          : 'PUBLICATION_INSPECTION_FAILED',
+        timedOut
+          ? 'The platform inspection timed out.'
+          : 'The platform inspection failed.',
+      ),
+    ]
+  }
+}

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -28,6 +28,14 @@ import {
 import { checkSyncFrequency, recordSync } from '../lib/rate-limit'
 import { checkForUpdates, isUpdateDismissed } from '../lib/version-check'
 import { fetchRemoteConfig, fetchConfigIfNeeded } from '../lib/remote-config'
+import {
+  buildSyncerAccountsV2,
+  runPublicationInspection,
+  validateBridgeMessageSender,
+  validateGetAccountsV2Payload,
+  validateInspectPublicationPayload,
+} from './bridge-v2'
+import { dispatchLegacyMagicCall } from '../bridge/legacy-magic-call'
 
 const logger = createLogger('Background')
 
@@ -124,6 +132,8 @@ async function clearSyncState() {
 type MessageAction =
   | { type: 'GET_PLATFORMS' }
   | { type: 'CHECK_ALL_AUTH'; payload?: { forceRefresh?: boolean } }
+  | { type: 'BRIDGE_GET_ACCOUNTS_V2'; requestId: string; payload: unknown }
+  | { type: 'BRIDGE_INSPECT_PUBLICATION'; requestId: string; payload: unknown }
   | { type: 'CHECK_AUTH'; payload: { platformId: string } }
   | { type: 'SYNC_ARTICLE'; payload: { article: any; platforms: string[]; allSelectedPlatforms?: string[]; skipHistory?: boolean; source?: string; syncId?: string } }
   | { type: 'OPEN_SYNC_PAGE'; path?: string }
@@ -196,6 +206,52 @@ async function handleMessage(message: MessageAction, sender?: chrome.runtime.Mes
       // 缓存完整平台列表，供 popup 启动时立即渲染
       chrome.storage.local.set({ platformListCache: allPlatforms }).catch(() => {})
       return { platforms: allPlatforms }
+    }
+
+    case 'BRIDGE_GET_ACCOUNTS_V2': {
+      const verifiedSender = validateBridgeMessageSender(sender || {})
+      if (!verifiedSender.success) {
+        return { error: verifiedSender.code }
+      }
+
+      const validatedPayload = validateGetAccountsV2Payload(message.payload)
+      if (!validatedPayload.success) {
+        return { error: validatedPayload.code }
+      }
+
+      const authResults = await checkAllPlatformsAuth(
+        validatedPayload.data.forceRefresh ?? false,
+        validatedPayload.data.platforms,
+      )
+      return {
+        accounts: buildSyncerAccountsV2(
+          authResults,
+          validatedPayload.data.platforms
+        ),
+      }
+    }
+
+    case 'BRIDGE_INSPECT_PUBLICATION': {
+      const verifiedSender = validateBridgeMessageSender(sender || {})
+      if (!verifiedSender.success) {
+        return { error: verifiedSender.code }
+      }
+
+      const validatedPayload = validateInspectPublicationPayload(
+        message.payload,
+        message.requestId
+      )
+      if (!validatedPayload.success) {
+        return { error: validatedPayload.code }
+      }
+
+      const adapter = await getAdapter(validatedPayload.data.platform)
+      return {
+        observations: await runPublicationInspection(
+          validatedPayload.data,
+          adapter,
+        ),
+      }
     }
 
     case 'CHECK_AUTH': {
@@ -963,28 +1019,7 @@ async function handleMessage(message: MessageAction, sender?: chrome.runtime.Mes
 
     case 'MAGIC_CALL': {
       const { methodName, data } = message.payload
-
-      try {
-        // 获取平台适配器
-        const platform = data.account?.type || data.platform || 'weibo'
-        const adapter = await getAdapter(platform)
-
-        if (!adapter) {
-          return { error: `Platform not found: ${platform}` }
-        }
-
-        // 检查方法是否存在
-        if (typeof (adapter as any)[methodName] !== 'function') {
-          return { error: `Method ${methodName} not found on platform ${platform}` }
-        }
-
-        // 调用方法
-        const result = await (adapter as any)[methodName](data)
-        return { result }
-      } catch (error) {
-        logger.error(`Magic call ${methodName} failed:`, error)
-        return { error: (error as Error).message }
-      }
+      return dispatchLegacyMagicCall(methodName, data)
     }
 
     case 'CLEAR_UPDATE_BADGE': {
@@ -1275,7 +1310,9 @@ interface SyncResult {
   platform: string
   platformName?: string
   success: boolean
+  postId?: string
   postUrl?: string
+  url?: string
   draftOnly?: boolean
   error?: string
 }

--- a/packages/extension/src/bridge/index.ts
+++ b/packages/extension/src/bridge/index.ts
@@ -1,0 +1,3 @@
+export * from './protocol'
+export * from './legacy-account'
+export * from './legacy-magic-call'

--- a/packages/extension/src/bridge/legacy-account.ts
+++ b/packages/extension/src/bridge/legacy-account.ts
@@ -1,0 +1,57 @@
+export interface LegacyAccountSummary {
+  type: string
+  title: string
+  displayName: string
+  icon?: string
+  avatar?: string
+  uid?: string
+  home?: string
+  supportTypes: ['html']
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : undefined
+}
+
+/**
+ * Preserve the legacy account shape without exposing stable account identity.
+ * Stable userId and the authenticated profile avatar are reserved for the
+ * exact-origin Bridge v2 account projection.
+ */
+export function projectLegacyAccounts(value: unknown): LegacyAccountSummary[] {
+  if (!Array.isArray(value)) return []
+
+  const accounts: LegacyAccountSummary[] = []
+  for (const candidate of value) {
+    if (
+      typeof candidate !== 'object' ||
+      candidate === null ||
+      Array.isArray(candidate)
+    ) {
+      continue
+    }
+
+    const platform = candidate as Record<string, unknown>
+    const type = asNonEmptyString(platform.id)
+    if (platform.isAuthenticated !== true || !type) continue
+
+    const name = asNonEmptyString(platform.name) ?? type
+    const username = asNonEmptyString(platform.username)
+    const icon = asNonEmptyString(platform.icon)
+    const home = asNonEmptyString(platform.homepage)
+
+    accounts.push({
+      type,
+      title: username ?? name,
+      displayName: name,
+      ...(icon ? { icon, avatar: icon } : {}),
+      ...(username ? { uid: username } : {}),
+      ...(home ? { home } : {}),
+      supportTypes: ['html'],
+    })
+  }
+
+  return accounts
+}

--- a/packages/extension/src/bridge/legacy-magic-call.ts
+++ b/packages/extension/src/bridge/legacy-magic-call.ts
@@ -1,0 +1,39 @@
+export const LEGACY_MAGIC_CALL_METHOD_NOT_ALLOWED =
+  'LEGACY_MAGIC_CALL_METHOD_NOT_ALLOWED'
+
+type LegacyMagicCallHandler = (data: unknown) => unknown | Promise<unknown>
+
+/**
+ * The unrestricted legacy page channel currently has no authorized adapter
+ * methods. Future compatibility methods must be added here as explicit,
+ * validated handlers; never dispatch a page-provided name onto an adapter.
+ */
+const LEGACY_MAGIC_CALL_HANDLERS: Readonly<
+  Record<string, LegacyMagicCallHandler>
+> = Object.freeze({})
+
+export interface LegacyMagicCallResponse {
+  result?: unknown
+  error?: string
+}
+
+export async function dispatchLegacyMagicCall(
+  methodName: unknown,
+  data: unknown,
+): Promise<LegacyMagicCallResponse> {
+  if (
+    typeof methodName !== 'string' ||
+    !Object.prototype.hasOwnProperty.call(
+      LEGACY_MAGIC_CALL_HANDLERS,
+      methodName,
+    )
+  ) {
+    return { error: LEGACY_MAGIC_CALL_METHOD_NOT_ALLOWED }
+  }
+
+  try {
+    return { result: await LEGACY_MAGIC_CALL_HANDLERS[methodName](data) }
+  } catch {
+    return { error: 'LEGACY_MAGIC_CALL_FAILED' }
+  }
+}

--- a/packages/extension/src/bridge/protocol.ts
+++ b/packages/extension/src/bridge/protocol.ts
@@ -1,0 +1,556 @@
+import {
+  PublicationInspectRequestSchema,
+  PublicationObservationSchema,
+  PublicationPlatformSchema,
+  SYNCER_BRIDGE_REQUEST_ID_MAX_LENGTH,
+  SyncerAccountV2Schema,
+  SyncerBridgeInfoSchema,
+  type PublicationInspectRequest,
+  type PublicationObservation,
+  type PublicationPlatform,
+  type SyncerAccountV2,
+  type SyncerBridgeInfo,
+} from '@wechatsync/core/publication-inspection'
+
+export const BRIDGE_NAMESPACE = 'vibemarket.syncer.bridge' as const
+export const BRIDGE_API_VERSION = '2.0' as const
+
+export const BRIDGE_DIRECTIONS = {
+  request: 'PAGE_TO_EXTENSION',
+  response: 'EXTENSION_TO_PAGE',
+} as const
+
+export const BRIDGE_METHODS = [
+  'getBridgeInfo',
+  'getAccountsV2',
+  'inspectPublication',
+] as const
+
+export type BridgeMethod = (typeof BRIDGE_METHODS)[number]
+
+/**
+ * Phase 0 deliberately allows only the canonical port-80 localhost origin.
+ * Other environment origins must be added explicitly in a later build.
+ */
+export const DEFAULT_BRIDGE_ALLOWED_ORIGINS = ['http://localhost'] as const
+
+export interface GetAccountsV2Payload {
+  platforms?: PublicationPlatform[]
+  forceRefresh?: boolean
+}
+
+export interface BridgeRequestPayloadMap {
+  getBridgeInfo: Record<string, never>
+  getAccountsV2: GetAccountsV2Payload
+  inspectPublication: PublicationInspectRequest
+}
+
+export interface BridgeResponseResultMap {
+  getBridgeInfo: SyncerBridgeInfo
+  getAccountsV2: SyncerAccountV2[]
+  inspectPublication: PublicationObservation[]
+}
+
+export type BridgeRequestFor<M extends BridgeMethod> = {
+  namespace: typeof BRIDGE_NAMESPACE
+  apiVersion: typeof BRIDGE_API_VERSION
+  direction: typeof BRIDGE_DIRECTIONS.request
+  requestId: string
+  method: M
+  payload: BridgeRequestPayloadMap[M]
+}
+
+export type BridgeRequest = {
+  [M in BridgeMethod]: BridgeRequestFor<M>
+}[BridgeMethod]
+
+export type BridgeSuccessResponseFor<M extends BridgeMethod> = {
+  namespace: typeof BRIDGE_NAMESPACE
+  apiVersion: typeof BRIDGE_API_VERSION
+  direction: typeof BRIDGE_DIRECTIONS.response
+  requestId: string
+  method: M
+  ok: true
+  result: BridgeResponseResultMap[M]
+}
+
+export interface BridgeError {
+  code: string
+  message: string
+}
+
+export type BridgeErrorResponseFor<M extends BridgeMethod> = {
+  namespace: typeof BRIDGE_NAMESPACE
+  apiVersion: typeof BRIDGE_API_VERSION
+  direction: typeof BRIDGE_DIRECTIONS.response
+  requestId: string
+  method: M
+  ok: false
+  error: BridgeError
+}
+
+export type BridgeSuccessResponse = {
+  [M in BridgeMethod]: BridgeSuccessResponseFor<M>
+}[BridgeMethod]
+
+export type BridgeErrorResponse = {
+  [M in BridgeMethod]: BridgeErrorResponseFor<M>
+}[BridgeMethod]
+
+export type BridgeResponse = BridgeSuccessResponse | BridgeErrorResponse
+
+export type BridgeProtocolFailureCode =
+  | 'SOURCE_MISMATCH'
+  | 'ORIGIN_NOT_ALLOWED'
+  | 'INVALID_ENVELOPE'
+  | 'METHOD_NOT_ALLOWED'
+  | 'INVALID_PAYLOAD'
+
+export type BridgeParseResult<T> =
+  | { success: true; data: T }
+  | { success: false; code: BridgeProtocolFailureCode }
+
+export interface BridgeMessageEventLike {
+  origin: unknown
+  source: unknown
+  data: unknown
+}
+
+const REQUEST_ENVELOPE_KEYS = new Set([
+  'namespace',
+  'apiVersion',
+  'direction',
+  'requestId',
+  'method',
+  'payload',
+])
+
+const RESPONSE_SUCCESS_KEYS = new Set([
+  'namespace',
+  'apiVersion',
+  'direction',
+  'requestId',
+  'method',
+  'ok',
+  'result',
+])
+
+const RESPONSE_ERROR_KEYS = new Set([
+  'namespace',
+  'apiVersion',
+  'direction',
+  'requestId',
+  'method',
+  'ok',
+  'error',
+])
+
+const INSPECT_PAYLOAD_KEYS = new Set([
+  'requestId',
+  'platform',
+  'externalAccountId',
+  'draft',
+  'articleHint',
+  'limit',
+])
+
+const INSPECT_DRAFT_KEYS = new Set(['platformPostId', 'draftUrl', 'draftedAt'])
+
+const INSPECT_ARTICLE_HINT_KEYS = new Set([
+  'title',
+  'publishedAfter',
+  'publishedBefore',
+])
+
+const GET_ACCOUNTS_KEYS = new Set(['platforms', 'forceRefresh'])
+const ERROR_KEYS = new Set(['code', 'message'])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  allowedKeys: ReadonlySet<string>,
+): boolean {
+  return (
+    Object.getOwnPropertySymbols(value).length === 0 &&
+    Object.keys(value).every((key) => allowedKeys.has(key))
+  )
+}
+
+export function normalizeBridgeRequestId(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+
+  const normalized = value.trim()
+  return normalized.length > 0 &&
+    normalized.length <= SYNCER_BRIDGE_REQUEST_ID_MAX_LENGTH
+    ? normalized
+    : null
+}
+
+function isBridgeMethod(value: unknown): value is BridgeMethod {
+  return (
+    typeof value === 'string' &&
+    (BRIDGE_METHODS as readonly string[]).includes(value)
+  )
+}
+
+function isSafeAllowlistOrigin(origin: string): boolean {
+  if (origin.includes('*')) return false
+
+  try {
+    const parsed = new URL(origin)
+    if (parsed.origin !== origin) return false
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')
+      return false
+
+    if (parsed.hostname === 'localhost') {
+      return origin === 'http://localhost'
+    }
+
+    if (
+      parsed.hostname === '127.0.0.1' ||
+      parsed.hostname === '[::1]' ||
+      parsed.hostname === '::1'
+    ) {
+      return false
+    }
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function isAllowedBridgeOrigin(
+  origin: unknown,
+  allowedOrigins: readonly string[] = DEFAULT_BRIDGE_ALLOWED_ORIGINS,
+): origin is string {
+  if (typeof origin !== 'string') return false
+
+  return allowedOrigins.some(
+    (allowedOrigin) =>
+      isSafeAllowlistOrigin(allowedOrigin) && origin === allowedOrigin,
+  )
+}
+
+function parseGetBridgeInfoPayload(
+  value: unknown,
+): Record<string, never> | null {
+  if (typeof value === 'undefined') return {}
+  if (!isRecord(value) || Object.keys(value).length !== 0) return null
+  return {}
+}
+
+function parseGetAccountsV2Payload(
+  value: unknown,
+): GetAccountsV2Payload | null {
+  if (!isRecord(value) || !hasOnlyKeys(value, GET_ACCOUNTS_KEYS)) return null
+
+  const { platforms, forceRefresh } = value
+  if (
+    typeof forceRefresh !== 'undefined' &&
+    typeof forceRefresh !== 'boolean'
+  ) {
+    return null
+  }
+
+  let parsedPlatforms: PublicationPlatform[] | undefined
+  if (typeof platforms !== 'undefined') {
+    if (!Array.isArray(platforms) || platforms.length > 4) return null
+
+    parsedPlatforms = []
+    for (const platform of platforms) {
+      const parsed = PublicationPlatformSchema.safeParse(platform)
+      if (!parsed.success || parsedPlatforms.includes(parsed.data)) return null
+      parsedPlatforms.push(parsed.data)
+    }
+  }
+
+  return {
+    ...(parsedPlatforms ? { platforms: parsedPlatforms } : {}),
+    ...(typeof forceRefresh === 'boolean' ? { forceRefresh } : {}),
+  }
+}
+
+function hasStrictInspectPayloadShape(value: unknown): boolean {
+  if (!isRecord(value) || !hasOnlyKeys(value, INSPECT_PAYLOAD_KEYS)) {
+    return false
+  }
+
+  return (
+    isRecord(value.draft) &&
+    hasOnlyKeys(value.draft, INSPECT_DRAFT_KEYS) &&
+    isRecord(value.articleHint) &&
+    hasOnlyKeys(value.articleHint, INSPECT_ARTICLE_HINT_KEYS)
+  )
+}
+
+function parseInspectPublicationPayload(
+  value: unknown,
+  envelopeRequestId: string,
+): PublicationInspectRequest | null {
+  if (!hasStrictInspectPayloadShape(value)) return null
+
+  const parsed = PublicationInspectRequestSchema.safeParse(value)
+  if (!parsed.success || parsed.data.requestId !== envelopeRequestId)
+    return null
+  return parsed.data
+}
+
+function parseRequestPayload<M extends BridgeMethod>(
+  method: M,
+  value: unknown,
+  requestId: string,
+): BridgeRequestPayloadMap[M] | null {
+  switch (method) {
+    case 'getBridgeInfo':
+      return parseGetBridgeInfoPayload(value) as
+        | BridgeRequestPayloadMap[M]
+        | null
+    case 'getAccountsV2':
+      return parseGetAccountsV2Payload(value) as
+        | BridgeRequestPayloadMap[M]
+        | null
+    case 'inspectPublication':
+      return parseInspectPublicationPayload(value, requestId) as
+        | BridgeRequestPayloadMap[M]
+        | null
+  }
+}
+
+function validateEventBoundary(
+  event: BridgeMessageEventLike,
+  expectedSource: unknown,
+  allowedOrigins: readonly string[],
+): BridgeParseResult<never> | null {
+  if (event.source !== expectedSource) {
+    return { success: false, code: 'SOURCE_MISMATCH' }
+  }
+
+  if (!isAllowedBridgeOrigin(event.origin, allowedOrigins)) {
+    return { success: false, code: 'ORIGIN_NOT_ALLOWED' }
+  }
+
+  return null
+}
+
+export function parseBridgeRequestEvent(
+  event: BridgeMessageEventLike,
+  expectedSource: unknown,
+  allowedOrigins: readonly string[] = DEFAULT_BRIDGE_ALLOWED_ORIGINS,
+): BridgeParseResult<BridgeRequest> {
+  const boundaryFailure = validateEventBoundary(
+    event,
+    expectedSource,
+    allowedOrigins,
+  )
+  if (boundaryFailure) return boundaryFailure
+
+  if (
+    !isRecord(event.data) ||
+    !hasOnlyKeys(event.data, REQUEST_ENVELOPE_KEYS)
+  ) {
+    return { success: false, code: 'INVALID_ENVELOPE' }
+  }
+
+  const { data } = event
+  const requestId = normalizeBridgeRequestId(data.requestId)
+  if (
+    data.namespace !== BRIDGE_NAMESPACE ||
+    data.apiVersion !== BRIDGE_API_VERSION ||
+    data.direction !== BRIDGE_DIRECTIONS.request ||
+    requestId === null
+  ) {
+    return { success: false, code: 'INVALID_ENVELOPE' }
+  }
+
+  if (!isBridgeMethod(data.method)) {
+    return { success: false, code: 'METHOD_NOT_ALLOWED' }
+  }
+
+  const payload = parseRequestPayload(data.method, data.payload, requestId)
+  if (payload === null) {
+    return { success: false, code: 'INVALID_PAYLOAD' }
+  }
+
+  return {
+    success: true,
+    data: {
+      namespace: BRIDGE_NAMESPACE,
+      apiVersion: BRIDGE_API_VERSION,
+      direction: BRIDGE_DIRECTIONS.request,
+      requestId,
+      method: data.method,
+      payload,
+    } as BridgeRequest,
+  }
+}
+
+function parseResponseResult<M extends BridgeMethod>(
+  method: M,
+  value: unknown,
+): BridgeResponseResultMap[M] | null {
+  if (method === 'getBridgeInfo') {
+    const parsed = SyncerBridgeInfoSchema.safeParse(value)
+    return parsed.success ? (parsed.data as BridgeResponseResultMap[M]) : null
+  }
+
+  if (!Array.isArray(value)) return null
+
+  if (method === 'getAccountsV2') {
+    const parsed = value.map((account) =>
+      SyncerAccountV2Schema.safeParse(account),
+    )
+    return parsed.every((result) => result.success)
+      ? (parsed.map((result) => result.data) as BridgeResponseResultMap[M])
+      : null
+  }
+
+  const parsed = value.map((observation) =>
+    PublicationObservationSchema.safeParse(observation),
+  )
+  return parsed.every((result) => result.success)
+    ? (parsed.map((result) => result.data) as BridgeResponseResultMap[M])
+    : null
+}
+
+function parseBridgeError(value: unknown): BridgeError | null {
+  if (!isRecord(value) || !hasOnlyKeys(value, ERROR_KEYS)) return null
+
+  if (
+    typeof value.code !== 'string' ||
+    value.code.length === 0 ||
+    value.code.length > 100 ||
+    typeof value.message !== 'string' ||
+    value.message.length === 0 ||
+    value.message.length > 2_000
+  ) {
+    return null
+  }
+
+  return { code: value.code, message: value.message }
+}
+
+export function parseBridgeResponseEvent(
+  event: BridgeMessageEventLike,
+  expectedSource: unknown,
+  allowedOrigins: readonly string[] = DEFAULT_BRIDGE_ALLOWED_ORIGINS,
+): BridgeParseResult<BridgeResponse> {
+  const boundaryFailure = validateEventBoundary(
+    event,
+    expectedSource,
+    allowedOrigins,
+  )
+  if (boundaryFailure) return boundaryFailure
+
+  if (!isRecord(event.data)) {
+    return { success: false, code: 'INVALID_ENVELOPE' }
+  }
+
+  const { data } = event
+  const requestId = normalizeBridgeRequestId(data.requestId)
+  const expectedKeys =
+    data.ok === true ? RESPONSE_SUCCESS_KEYS : RESPONSE_ERROR_KEYS
+  if (
+    !hasOnlyKeys(data, expectedKeys) ||
+    data.namespace !== BRIDGE_NAMESPACE ||
+    data.apiVersion !== BRIDGE_API_VERSION ||
+    data.direction !== BRIDGE_DIRECTIONS.response ||
+    requestId === null
+  ) {
+    return { success: false, code: 'INVALID_ENVELOPE' }
+  }
+
+  if (!isBridgeMethod(data.method)) {
+    return { success: false, code: 'METHOD_NOT_ALLOWED' }
+  }
+
+  if (data.ok === true) {
+    const result = parseResponseResult(data.method, data.result)
+    if (result === null) {
+      return { success: false, code: 'INVALID_PAYLOAD' }
+    }
+
+    return {
+      success: true,
+      data: {
+        namespace: BRIDGE_NAMESPACE,
+        apiVersion: BRIDGE_API_VERSION,
+        direction: BRIDGE_DIRECTIONS.response,
+        requestId,
+        method: data.method,
+        ok: true,
+        result,
+      } as BridgeSuccessResponse,
+    }
+  }
+
+  if (data.ok !== false) {
+    return { success: false, code: 'INVALID_ENVELOPE' }
+  }
+
+  const error = parseBridgeError(data.error)
+  if (error === null) {
+    return { success: false, code: 'INVALID_PAYLOAD' }
+  }
+
+  return {
+    success: true,
+    data: {
+      namespace: BRIDGE_NAMESPACE,
+      apiVersion: BRIDGE_API_VERSION,
+      direction: BRIDGE_DIRECTIONS.response,
+      requestId,
+      method: data.method,
+      ok: false,
+      error,
+    } as BridgeErrorResponse,
+  }
+}
+
+export function createBridgeSuccessResponse<M extends BridgeMethod>(
+  request: BridgeRequestFor<M>,
+  result: BridgeResponseResultMap[M],
+): BridgeSuccessResponseFor<M> {
+  const parsedResult = parseResponseResult(request.method, result)
+  if (parsedResult === null) {
+    throw new TypeError(`Invalid result for bridge method ${request.method}`)
+  }
+
+  return {
+    namespace: BRIDGE_NAMESPACE,
+    apiVersion: BRIDGE_API_VERSION,
+    direction: BRIDGE_DIRECTIONS.response,
+    requestId: request.requestId,
+    method: request.method,
+    ok: true,
+    result: parsedResult,
+  }
+}
+
+export function createBridgeErrorResponse<M extends BridgeMethod>(
+  request: BridgeRequestFor<M>,
+  error: BridgeError,
+): BridgeErrorResponseFor<M> {
+  const parsedError = parseBridgeError(error)
+  if (parsedError === null) {
+    throw new TypeError('Invalid bridge error')
+  }
+
+  return {
+    namespace: BRIDGE_NAMESPACE,
+    apiVersion: BRIDGE_API_VERSION,
+    direction: BRIDGE_DIRECTIONS.response,
+    requestId: request.requestId,
+    method: request.method,
+    ok: false,
+    error: parsedError,
+  }
+}

--- a/packages/extension/src/bridge/sync-result.ts
+++ b/packages/extension/src/bridge/sync-result.ts
@@ -1,0 +1,46 @@
+import { sanitizeSyncResultForBoundary } from '@wechatsync/core/publication-inspection'
+
+export interface LegacyEditResponse {
+  draftLink?: string
+  postId?: string
+}
+
+function boundedPostId(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim()
+  return normalized.length > 0 &&
+    normalized.length <= 500 &&
+    !/[\u0000-\u001f\u007f]/.test(normalized)
+    ? normalized
+    : undefined
+}
+
+/**
+ * Project a platform sync result onto the narrow legacy account status shape.
+ * The projection is a second defense after the adapter boundary: token-bearing
+ * WeChat URLs can never be posted into the page, while stable postId survives.
+ */
+export function toLegacyEditResponse(
+  value: unknown,
+): LegacyEditResponse | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null
+  }
+
+  const result = value as Record<string, unknown>
+  if (result.success !== true) return null
+
+  const sanitized = sanitizeSyncResultForBoundary(result)
+  const draftLink =
+    typeof sanitized.postUrl === 'string'
+      ? sanitized.postUrl
+      : typeof sanitized.url === 'string'
+        ? sanitized.url
+        : undefined
+  const postId = boundedPostId(sanitized.postId)
+
+  return {
+    ...(draftLink ? { draftLink } : {}),
+    ...(postId ? { postId } : {}),
+  }
+}

--- a/packages/extension/src/content/api.ts
+++ b/packages/extension/src/content/api.ts
@@ -13,7 +13,24 @@
  */
 
 import { htmlToMarkdownNative } from '@wechatsync/core'
+import type {
+  PublicationObservation,
+  SyncerAccountV2,
+} from '@wechatsync/core/publication-inspection'
 import { createLogger } from '../lib/logger'
+import {
+  BRIDGE_API_VERSION,
+  BRIDGE_NAMESPACE,
+  createBridgeErrorResponse,
+  createBridgeSuccessResponse,
+  parseBridgeRequestEvent,
+  type BridgeErrorResponse,
+  type BridgeRequest,
+  type BridgeResponse,
+} from '../bridge'
+import { projectLegacyAccounts } from '../bridge/legacy-account'
+import { LEGACY_MAGIC_CALL_METHOD_NOT_ALLOWED } from '../bridge/legacy-magic-call'
+import { toLegacyEditResponse } from '../bridge/sync-result'
 
 const logger = createLogger('Wechatsync')
 
@@ -23,6 +40,18 @@ const SENSITIVE_API_WHITELIST = [
   'https://developer.wechatsync.com',
   'http://localhost:8080',
 ];
+
+const BRIDGE_CAPABILITIES = [
+  'account_identity',
+  'publication_inspect',
+  'public_url',
+] as const
+
+interface BridgeRuntimeResponse {
+  accounts?: SyncerAccountV2[]
+  observations?: PublicationObservation[]
+  error?: string
+}
 
 // 当前同步任务 ID（用于过滤消息）
 let currentSyncId: string | null = null;
@@ -40,7 +69,7 @@ interface AccountStatus {
   status: 'pending' | 'uploading' | 'done' | 'failed';
   msg?: string;
   error?: string;
-  editResp?: { draftLink?: string } | null;
+  editResp?: { draftLink?: string; postId?: string } | null;
 }
 let currentAccounts: AccountStatus[] = [];
 
@@ -71,6 +100,124 @@ function sendConsoleLog(args: unknown) {
     args,
   }), '*');
 }
+
+function postBridgeResponse(response: BridgeResponse, targetOrigin: string) {
+  window.postMessage(response, targetOrigin)
+}
+
+function createBridgeFailure(
+  request: BridgeRequest,
+  code: string,
+  message: string
+): BridgeErrorResponse {
+  switch (request.method) {
+    case 'getBridgeInfo':
+      return createBridgeErrorResponse(request, { code, message })
+    case 'getAccountsV2':
+      return createBridgeErrorResponse(request, { code, message })
+    case 'inspectPublication':
+      return createBridgeErrorResponse(request, { code, message })
+  }
+}
+
+function sendBridgeRuntimeMessage(
+  message: Record<string, unknown>
+): Promise<BridgeRuntimeResponse> {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage(message, (response: BridgeRuntimeResponse) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message))
+        return
+      }
+
+      if (response?.error) {
+        reject(new Error(response.error))
+        return
+      }
+
+      resolve(response || {})
+    })
+  })
+}
+
+async function handleBridgeRequest(evt: MessageEvent): Promise<void> {
+  if (window.top !== window) return
+
+  const data = evt.data
+  if (
+    typeof data !== 'object' ||
+    data === null ||
+    data.namespace !== BRIDGE_NAMESPACE
+  ) {
+    return
+  }
+
+  const parsed = parseBridgeRequestEvent(evt, window)
+  if (!parsed.success) return
+
+  const request = parsed.data
+
+  try {
+    switch (request.method) {
+      case 'getBridgeInfo': {
+        postBridgeResponse(
+          createBridgeSuccessResponse(request, {
+            apiVersion: BRIDGE_API_VERSION,
+            extensionVersion: chrome.runtime.getManifest().version,
+            capabilities: [...BRIDGE_CAPABILITIES],
+          }),
+          evt.origin
+        )
+        return
+      }
+
+      case 'getAccountsV2': {
+        const response = await sendBridgeRuntimeMessage({
+          type: 'BRIDGE_GET_ACCOUNTS_V2',
+          requestId: request.requestId,
+          payload: request.payload,
+        })
+        if (!response.accounts) {
+          throw new Error('Bridge account response is missing')
+        }
+        postBridgeResponse(
+          createBridgeSuccessResponse(request, response.accounts),
+          evt.origin
+        )
+        return
+      }
+
+      case 'inspectPublication': {
+        const response = await sendBridgeRuntimeMessage({
+          type: 'BRIDGE_INSPECT_PUBLICATION',
+          requestId: request.requestId,
+          payload: request.payload,
+        })
+        if (!response.observations) {
+          throw new Error('Bridge inspection response is missing')
+        }
+        postBridgeResponse(
+          createBridgeSuccessResponse(request, response.observations),
+          evt.origin
+        )
+        return
+      }
+    }
+  } catch (error) {
+    postBridgeResponse(
+      createBridgeFailure(
+        request,
+        'BRIDGE_RUNTIME_ERROR',
+        (error as Error).message || 'Bridge request failed'
+      ),
+      evt.origin
+    )
+  }
+}
+
+window.addEventListener('message', (evt) => {
+  void handleBridgeRequest(evt)
+})
 
 /**
  * 监听来自 background 的消息
@@ -110,7 +257,7 @@ chrome.runtime.onMessage.addListener((message, _sender, _sendResponse) => {
           account.status = result.success ? 'done' : 'failed';
           account.error = result.error;
           account.msg = undefined;
-          account.editResp = result.success ? { draftLink: result.postUrl || result.url } : null;
+          account.editResp = toLegacyEditResponse(result);
         }
         // 发送完整的账户状态列表
         sendTaskUpdate({ accounts: currentAccounts });
@@ -160,18 +307,7 @@ window.addEventListener('message', async (evt) => {
         }
 
         // 只返回已登录的平台（与旧版保持一致）
-        const accounts = (resp?.platforms || [])
-          .filter((p: any) => p.isAuthenticated)
-          .map((p: any) => ({
-            type: p.id,
-            title: p.username || p.name,
-            displayName: p.name,
-            icon: p.icon,
-            avatar: p.icon,
-            uid: p.username,
-            home: p.homepage,
-            supportTypes: ['html'],
-          }));
+        const accounts = projectLegacyAccounts(resp?.platforms || []);
 
         sendToWindow({ eventID: action.eventID, result: accounts });
       });
@@ -250,16 +386,9 @@ window.addEventListener('message', async (evt) => {
           sendToWindow({ eventID: action.eventID, result: resp });
         });
       } else {
-        // 其他 magicCall 方法
-        chrome.runtime.sendMessage({
-          type: 'MAGIC_CALL',
-          payload: { methodName, data },
-        }, (resp) => {
-          if (chrome.runtime.lastError) {
-            sendToWindow({ eventID: action.eventID, result: { error: chrome.runtime.lastError.message } });
-            return;
-          }
-          sendToWindow({ eventID: action.eventID, result: resp });
+        sendToWindow({
+          eventID: action.eventID,
+          result: { error: LEGACY_MAGIC_CALL_METHOD_NOT_ALLOWED },
         });
       }
     }

--- a/packages/extension/src/runtime/extension.ts
+++ b/packages/extension/src/runtime/extension.ts
@@ -26,7 +26,7 @@ export class ExtensionRuntime implements RuntimeInterface {
     try {
       const response = await fetch(url, {
         ...options,
-        credentials: 'include',
+        credentials: options?.credentials ?? 'include',
         signal: controller.signal,
       })
       return response

--- a/packages/extension/vitest.config.ts
+++ b/packages/extension/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@wechatsync/core': path.resolve(__dirname, '../core/src'),
     },
   },
 })


### PR DESCRIPTION
## What

- add a versioned Bridge v2 for `getBridgeInfo`, stable account identity, and publication inspection
- restrict the page boundary to the exact `http://localhost` origin and revalidate sender, frame, request ID, and payload in the background worker
- add a platform-neutral publication observation contract and a Zhihu inspector for exact draft IDs, anonymous public visibility, author ownership, publication state, canonical URL, and published time
- fail closed on timeouts, parse drift, account mismatch, and unsupported platforms instead of inferring `NOT_FOUND`
- keep Sohu, WeChat, and Toutiao publication inspection paused behind an extension-side Zhihu-only rollout gate

## Security and compatibility

- public Zhihu evidence is fetched with `credentials: omit`; authenticated draft/account requests still use `include`
- stable account IDs and authenticated avatars are exposed only through the exact-origin Bridge v2 projection; the global legacy account projection stays redacted
- page-bound sync results are sanitized without changing internal extension navigation results
- generic legacy `magicCall` is now fail-closed to prevent adapter method-name dispatch from bypassing Bridge v2; the existing dedicated `uploadImage` path remains available

## Validation

- Core: 116 tests passed
- Extension: 77 tests passed
- Core and Extension TypeScript checks passed
- Core and Extension production builds passed
- staged diff check passed
- user manually validated the Zhihu draft inspection flow on the preceding 2.0.14 internal build

## Draft follow-ups

- [ ] reload the 2.0.15 internal build and replay a real published Zhihu sample after the anonymous-credentials boundary fix
- [ ] confirm whether Zhihu `article.created` is the true publish time for draft-to-published attribution
- [ ] normalize/reject non-canonical request IDs before callback registration
- [ ] propagate cancellation so the 12-second inspection timeout aborts the underlying fetch

This PR intentionally excludes the Sohu, WeChat, and Toutiao inspector implementations and the unrelated branding/Sohu-table commit.