### PR TITLE
fix: 修复 CMS 发布时未读取文章正文的问题

### DIFF
--- a/packages/extension/__tests__/cms-content-fallback.test.ts
+++ b/packages/extension/__tests__/cms-content-fallback.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { publish as publishWordPress } from "../src/adapters/cms/wordpress.ts";
+import {
+  publish as publishMetaWeblog,
+  publishToTypecho,
+} from "../src/adapters/cms/metaweblog.ts";
+
+const credentials = {
+  url: "https://blog.example.com",
+  username: "author",
+  password: "application-password",
+};
+
+function successfulXmlRpcResponse() {
+  return new Response(
+    '<?xml version="1.0"?><methodResponse><params><param><value><string>123</string></value></param></params></methodResponse>',
+    { status: 200, headers: { "content-type": "text/xml" } },
+  );
+}
+
+function mockSuccessfulFetch() {
+  const fetchMock = vi
+    .fn()
+    .mockImplementation(async () => successfulXmlRpcResponse());
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function requestBody(fetchMock: ReturnType<typeof vi.fn>): string {
+  return String(fetchMock.mock.calls[0]?.[1]?.body || "");
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("CMS article content fallback", () => {
+  it("publishes editor HTML through WordPress when content is absent", async () => {
+    const fetchMock = mockSuccessfulFetch();
+
+    const result = await publishWordPress(
+      credentials,
+      {
+        title: "HTML article",
+        html: "<p>Hello WordPress</p>",
+      },
+      { processImages: false },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+    expect(requestBody(fetchMock)).toContain(
+      "&lt;p&gt;Hello WordPress&lt;/p&gt;",
+    );
+  });
+
+  it("publishes editor HTML through MetaWeblog when content is absent", async () => {
+    const fetchMock = mockSuccessfulFetch();
+
+    const result = await publishMetaWeblog(
+      credentials,
+      {
+        title: "HTML article",
+        html: "<p>Hello MetaWeblog</p>",
+      },
+      { processImages: false },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+    expect(requestBody(fetchMock)).toContain(
+      "&lt;p&gt;Hello MetaWeblog&lt;/p&gt;",
+    );
+  });
+
+  it("publishes editor HTML through Typecho when content is absent", async () => {
+    const fetchMock = mockSuccessfulFetch();
+
+    const result = await publishToTypecho(
+      credentials,
+      {
+        title: "HTML article",
+        html: "<p>Hello Typecho</p>",
+      },
+      { processImages: false },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+    expect(requestBody(fetchMock)).toContain(
+      "&lt;p&gt;Hello Typecho&lt;/p&gt;",
+    );
+  });
+});

--- a/packages/extension/src/adapters/cms/metaweblog.ts
+++ b/packages/extension/src/adapters/cms/metaweblog.ts
@@ -485,14 +485,14 @@ export async function processArticleImages(
  */
 export async function publish(
   credentials: MetaWeblogCredentials,
-  article: { title: string; content: string },
+  article: { title: string; content?: string; html?: string; markdown?: string },
   options?: { draftOnly?: boolean; processImages?: boolean; onImageProgress?: (current: number, total: number) => void }
 ): Promise<{ success: boolean; postId?: string; postUrl?: string; message?: string; error?: string }> {
   const endpoint = getEndpoint(credentials)
 
   try {
     // 如果启用图片处理，先处理文章中的图片
-    let content = article.content
+    let content = article.content || article.html || article.markdown || ''
     let failedImages = 0
     if (options?.processImages !== false) {
       logger.debug(' Processing images before publish...')
@@ -651,7 +651,7 @@ export async function testTypechoConnection(credentials: MetaWeblogCredentials):
  */
 export async function publishToTypecho(
   credentials: MetaWeblogCredentials,
-  article: { title: string; content: string },
+  article: { title: string; content?: string; html?: string; markdown?: string },
   options?: { draftOnly?: boolean; processImages?: boolean; onImageProgress?: (current: number, total: number) => void; signal?: AbortSignal }
 ): Promise<{ success: boolean; postId?: string; postUrl?: string; message?: string; error?: string }> {
   const endpoint = credentials.url.replace(/\/$/, '') + '/action/xmlrpc'
@@ -661,7 +661,7 @@ export async function publishToTypecho(
 
   try {
     // 如果启用图片处理，先处理文章中的图片
-    let content = article.content
+    let content = article.content || article.html || article.markdown || ''
     let failedImages = 0
     if (options?.processImages !== false) {
       logger.debug(' Processing images before publish...')

--- a/packages/extension/src/adapters/cms/wordpress.ts
+++ b/packages/extension/src/adapters/cms/wordpress.ts
@@ -419,7 +419,7 @@ export async function processArticleImages(
  */
 export async function publish(
   credentials: WordPressCredentials,
-  article: { title: string; content: string },
+  article: { title: string; content?: string; html?: string; markdown?: string },
   options?: { draftOnly?: boolean; processImages?: boolean; onImageProgress?: (current: number, total: number) => void; signal?: AbortSignal }
 ): Promise<{ success: boolean; postId?: string; postUrl?: string; message?: string; error?: string }> {
   const xmlrpcUrl = credentials.url.replace(/\/$/, '') + '/xmlrpc.php'
@@ -431,7 +431,7 @@ export async function publish(
     }
 
     // 如果启用图片处理，先处理文章中的图片
-    let content = article.content
+    let content = article.content || article.html || article.markdown || ''
     let failedImages = 0
     if (options?.processImages !== false) {
       logger.debug(' Processing images before publish...')


### PR DESCRIPTION
## 问题说明

在文章编辑器中将文章同步到 WordPress、MetaWeblog 或 Typecho 时，CMS 连接测试可以正常通过，但实际保存草稿会失败。

界面显示以下错误：

```text
Cannot read properties of undefined (reading 'length')
```

## 复现步骤

1. 添加一个 WordPress、MetaWeblog 或 Typecho CMS 账户，并完成连接测试。
2. 打开任意文章并进入文章编辑器。
3. 选择已添加的 CMS 账户。
4. 点击同步，将文章保存到草稿。
5. 同步失败，并提示读取 `undefined.length`。

## 原因分析

当前文章同步流程传给平台适配器的正文主要位于：

- `article.html`：预处理后的 HTML。
- `article.markdown`：转换后的 Markdown。

这与 `CodeAdapter` 中约定的文章数据结构一致。

但是 WordPress、MetaWeblog 和 Typecho 适配器仍然只读取旧的 `article.content`：

```ts
let content = article.content
```

当编辑器传入的文章没有 `content` 字段时，适配器会将 `undefined` 传给后续的图片和正文处理流程，最终在解析正文时产生异常。

连接测试不涉及文章正文，因此连接测试仍然可以成功。

## 解决思路

在三个 CMS 适配器中按照以下顺序选择可用的文章正文：

```ts
let content = article.content || article.html || article.markdown || ''
```

1. 优先使用 `content`，保持对原有调用方的兼容。
2. `content` 不存在时，使用编辑器提供的 `html`。
3. HTML 不存在时，使用 `markdown`。
4. 最后回退到空字符串，避免将 `undefined` 传入正文处理流程。

同时更新适配器的文章参数类型，使 `content`、`html` 和 `markdown` 与实际可能收到的数据结构一致。

本次修改覆盖：

- WordPress
- MetaWeblog
- Typecho

## 修复效果

### 修改前

从编辑器同步文章到 WordPress 时失败：

```text
Cannot read properties of undefined (reading 'length')
```

<img width="563" height="500" alt="浮空页直接报错" src="https://github.com/user-attachments/assets/edc11ba9-5437-4eca-addf-8a723c198d96" />

### 修改后

使用相同文章和同一个 `ZWAWA Blog` CMS 账户重新同步，可以正常保存为草稿。

<img width="390" height="295" alt="详情成功" src="https://github.com/user-attachments/assets/cd35778b-72a5-49cd-b2c5-4320aa9200df" />

同步历史中也可以看到成功记录：

<img width="345" height="82" alt="成功" src="https://github.com/user-attachments/assets/37b21a4a-bd09-4582-a8a9-a3e95a894612" />


## 验证结果

- WordPress HTML 正文回退测试通过。
- MetaWeblog HTML 正文回退测试通过。
- Typecho HTML 正文回退测试通过。
- Extension 全量测试通过。
- TypeScript 类型检查通过。
- Extension 生产构建通过。