### PR TITLE
fix: improve CSDN sync formatting

### DIFF
--- a/packages/core/src/adapters/platforms/juejin.ts
+++ b/packages/core/src/adapters/platforms/juejin.ts
@@ -222,6 +222,16 @@ export class JuejinAdapter extends CodeAdapter {
         }
       )
 
+      let coverImage = ''
+      if (article.cover) {
+        try {
+          const coverResult = await this.uploadImageByUrl(article.cover)
+          coverImage = coverResult.url
+        } catch (error) {
+          logger.warn('Failed to upload cover image:', article.cover, error)
+        }
+      }
+
       // 6. 创建草稿 (参数来自 DSL juejin.yaml + juejin.transform.ts prepareBody)
       const createResponse = await this.runtime.fetch(
         'https://api.juejin.cn/content_api/v1/article_draft/create',
@@ -233,9 +243,9 @@ export class JuejinAdapter extends CodeAdapter {
             'x-secsdk-csrf-token': csrfToken,
           },
           body: JSON.stringify({
-            brief_content: '',
+            brief_content: this.buildBriefContent(article),
             category_id: '0',
-            cover_image: '',
+            cover_image: coverImage,
             edit_type: 10,
             html_content: 'deprecated',
             link_url: '',
@@ -283,6 +293,12 @@ export class JuejinAdapter extends CodeAdapter {
     }).catch((error) => this.createResult(false, {
       error: (error as Error).message,
     }))
+  }
+
+  private buildBriefContent(article: Article): string {
+    const summary = article.summary?.replace(/\s+/g, ' ').trim()
+    if (!summary) return ''
+    return summary.length > 100 ? summary.slice(0, 100) : summary
   }
 
   /**

--- a/packages/core/src/adapters/platforms/weixin.ts
+++ b/packages/core/src/adapters/platforms/weixin.ts
@@ -20,10 +20,12 @@ interface WeixinMeta {
 
 // 微信公众号的默认 CSS 样式
 const WEIXIN_CSS = `
-p {
+section, p, li, td, th {
   color: rgb(51, 51, 51);
   font-size: 15px;
   line-height: 1.75em;
+}
+p {
   margin: 0 0 1em 0;
 }
 h1, h2, h3, h4, h5, h6 {
@@ -33,11 +35,16 @@ h1 { font-size: 1.25em; line-height: 1.4em; margin: 1em 0 0.5em 0; }
 h2 { font-size: 1.125em; margin: 1em 0 0.5em 0; }
 h3 { font-size: 1.05em; margin: 0.8em 0 0.4em 0; }
 h4, h5, h6 { font-size: 1em; margin: 0.8em 0 0.4em 0; }
-li p { margin: 0; }
+li p { margin: 0; font-size: 15px; line-height: 1.75em; }
 ul, ol { margin: 1em 0; padding-left: 2em; }
-li { margin-bottom: 0.4em; }
-pre, tt, code, kbd, samp { font-family: monospace; }
-pre { white-space: pre; margin: 1em 0; }
+li > ul, li > ol { margin: 0.35em 0 0.35em 1em; padding-left: 1.5em; }
+li { margin-bottom: 0.4em; font-size: 15px; line-height: 1.75em; }
+table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 15px; line-height: 1.75em; }
+td, th { border: 1px solid #ddd; padding: 6px 8px; vertical-align: top; font-size: 15px; line-height: 1.75em; }
+pre, tt, code, kbd, samp { font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace; }
+code { background: #f6f8fa; border-radius: 3px; padding: 0.15em 0.35em; font-size: 13px; }
+pre { white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere; margin: 1em 0; padding: 12px; background: #f6f8fa; border-radius: 4px; line-height: 1.6; font-size: 13px; }
+pre code { display: block; padding: 0; background: transparent; border-radius: 0; font-size: inherit; }
 blockquote { border-left: 4px solid #ddd; padding-left: 1em; margin: 1em 0; color: #666; }
 hr { border: none; border-top: 1px solid #ddd; margin: 1.5em 0; }
 i, cite, em, var, address { font-style: italic; }
@@ -58,6 +65,8 @@ export class WeixinAdapter extends CodeAdapter {
     outputFormat: 'html' as const,
     removeLinks: true,
     keepLinkDomains: ['mp.weixin.qq.com', 'weixin.qq.com'],
+    normalizeLists: true,
+    linearizeTocLists: true,
     compactHtml: true,
   }
 
@@ -161,6 +170,7 @@ export class WeixinAdapter extends CodeAdapter {
             onProgress: options?.onImageProgress,
           }
         )
+        content = this.normalizeCodeBlocks(content)
         content = this.processContent(content)
       }
 
@@ -273,7 +283,9 @@ export class WeixinAdapter extends CodeAdapter {
       throw new Error('未登录')
     }
 
-    const imageResponse = await fetch(src)
+    const imageResponse = await this.runtime.fetch(src, {
+      method: 'GET',
+    })
     if (!imageResponse.ok) {
       throw new Error('图片下载失败: ' + src)
     }
@@ -281,7 +293,7 @@ export class WeixinAdapter extends CodeAdapter {
 
     const formData = new FormData()
     const timestamp = Date.now()
-    const fileName = `${timestamp}.jpg`
+    const fileName = `${timestamp}.${this.extensionForMime(imageBlob.type)}`
 
     formData.append('type', imageBlob.type || 'image/jpeg')
     formData.append('id', String(timestamp))
@@ -347,6 +359,43 @@ export class WeixinAdapter extends CodeAdapter {
   private processContent(content: string): string {
     const wrapped = `<section style="margin-left: 6px; margin-right: 6px; line-height: 1.75em;">${content}</section>`
     return juice.inlineContent(wrapped, WEIXIN_CSS)
+  }
+
+  private normalizeCodeBlocks(content: string): string {
+    return content.replace(/<pre([^>]*)>([\s\S]*?)<\/pre>/gi, (_match, attrs, inner) => {
+      const codeHtml = inner
+        .replace(/<\/?code[^>]*>/gi, '')
+        .replace(/<br\s*\/?>/gi, '\n')
+        .replace(/<\/(?:div|p|li)>/gi, '\n')
+        .replace(/<[^>]+>/g, '')
+        .replace(/\r\n/g, '\n')
+        .replace(/\r/g, '\n')
+        .replace(/^\n+|\n+$/g, '')
+
+      if (!codeHtml.trim()) {
+        return `<pre${attrs}></pre>`
+      }
+
+      const lines = codeHtml.split('\n')
+      const normalized = lines
+        .map((line: string) => `<span style="display:block;white-space:pre-wrap;min-height:1.6em;">${this.preserveCodeSpaces(line) || '&nbsp;'}</span>`)
+        .join('')
+
+      return `<pre${attrs}><code>${normalized}</code></pre>`
+    })
+  }
+
+  private preserveCodeSpaces(line: string): string {
+    return line.replace(/ {2}/g, ' &nbsp;').replace(/^\s+/, (spaces) => '&nbsp;'.repeat(spaces.length))
+  }
+
+  private extensionForMime(mime: string): string {
+    const normalized = mime.toLowerCase()
+    if (normalized.includes('png')) return 'png'
+    if (normalized.includes('gif')) return 'gif'
+    if (normalized.includes('webp')) return 'webp'
+    if (normalized.includes('jpeg') || normalized.includes('jpg')) return 'jpg'
+    return 'jpg'
   }
 
   /**

--- a/packages/core/src/adapters/platforms/weixin.ts
+++ b/packages/core/src/adapters/platforms/weixin.ts
@@ -67,6 +67,7 @@ export class WeixinAdapter extends CodeAdapter {
     keepLinkDomains: ['mp.weixin.qq.com', 'weixin.qq.com'],
     normalizeLists: true,
     linearizeTocLists: true,
+    flattenListItemText: true,
     compactHtml: true,
   }
 

--- a/packages/core/src/adapters/platforms/zhihu.ts
+++ b/packages/core/src/adapters/platforms/zhihu.ts
@@ -29,6 +29,7 @@ export class ZhihuAdapter extends CodeAdapter {
     removeSpecialTagsWithParent: true,
     // processDocCode: 处理代码块
     processCodeBlocks: true,
+    normalizeLists: true,
     convertSectionToDiv: true,
     removeTrailingBr: true,
     unwrapSingleChildContainers: true,
@@ -203,13 +204,30 @@ export class ZhihuAdapter extends CodeAdapter {
       '<figure><img$1src="$2"$3></figure>'
     )
 
-    // 3. 代码块格式
+    // 3. 代码块格式。预处理后的语言通常在 pre[data-lang] 或 pre.language-* 上。
     result = result.replace(
-      /<pre><code class="language-(\w+)">/gi,
-      '<pre lang="$1"><code>'
+      /<pre([^>]*)>([\s\S]*?)<\/pre>/gi,
+      (_match, attrs, inner) => {
+        const langMatch =
+          String(attrs).match(/\sdata-lang="([^"]+)"/i) ||
+          String(attrs).match(/\sdata-language="([^"]+)"/i) ||
+          String(attrs).match(/\slang="([^"]+)"/i) ||
+          String(attrs).match(/\sclass="[^"]*(?:language|lang)-([a-zA-Z0-9+#._-]+)[^"]*"/i) ||
+          String(inner).match(/<code[^>]*class="[^"]*(?:language|lang)-([a-zA-Z0-9+#._-]+)[^"]*"/i)
+        const lang = langMatch?.[1]?.replace(/[^a-zA-Z0-9+#._-]/g, '').toLowerCase()
+        const cleanedInner = String(inner)
+          .replace(/<code([^>]*)>/i, '<code>')
+        return lang ? `<pre lang="${lang}">${cleanedInner}</pre>` : `<pre>${cleanedInner}</pre>`
+      }
     )
 
-    // 4. 移除微信样式属性 (但保留知乎的 data-draft-* 属性)
+    // 4. 引用块格式 - 保留 blockquote 语义并给 Draft.js 入口明确块类型。
+    result = result.replace(
+      /<blockquote([^>]*)>/gi,
+      '<blockquote data-draft-node="block" data-draft-type="blockquote"$1>'
+    )
+
+    // 5. 移除微信样式属性 (但保留知乎的 data-draft-* 属性)
     result = result.replace(/\s*data-(?!draft)[a-z-]+="[^"]*"/gi, '')
     result = result.replace(/\s*style="[^"]*"/gi, '')
 

--- a/packages/core/src/adapters/types.ts
+++ b/packages/core/src/adapters/types.ts
@@ -40,6 +40,8 @@ export interface PreprocessConfig {
   normalizeLists?: boolean
   /** 将文章目录列表转换为缩进段落（适用于富文本编辑器不稳定支持嵌套列表的平台） */
   linearizeTocLists?: boolean
+  /** 将简单列表项内的 p/div/br 合并为单行文本 */
+  flattenListItemText?: boolean
 
   /** 移除空元素 (空 p, div, section 等) */
   removeEmptyElements?: boolean

--- a/packages/core/src/adapters/types.ts
+++ b/packages/core/src/adapters/types.ts
@@ -36,6 +36,11 @@ export interface PreprocessConfig {
   /** 处理懒加载图片 (data-src → src) */
   processLazyImages?: boolean
 
+  /** 规范化列表结构（修复源站生成的相邻嵌套列表和空列表项） */
+  normalizeLists?: boolean
+  /** 将文章目录列表转换为缩进段落（适用于富文本编辑器不稳定支持嵌套列表的平台） */
+  linearizeTocLists?: boolean
+
   /** 移除空元素 (空 p, div, section 等) */
   removeEmptyElements?: boolean
   /** 移除没有有效 src 的 img 标签（src 为空或缺失） */

--- a/packages/core/src/lib/__tests__/turndown.test.ts
+++ b/packages/core/src/lib/__tests__/turndown.test.ts
@@ -187,6 +187,19 @@ describe('htmlToMarkdown', () => {
       expect(markdown).toContain('```go')
     })
 
+    it('should detect language from pre class', () => {
+      const html = '<pre class="language-typescript"><code>const x: number = 1;</code></pre>'
+      const markdown = htmlToMarkdown(html)
+      expect(markdown).toContain('```typescript')
+    })
+
+    it('should not default unknown code blocks to bash', () => {
+      const html = '<pre><code>const x = 1;</code></pre>'
+      const markdown = htmlToMarkdown(html)
+      expect(markdown).toContain('```\nconst x = 1;')
+      expect(markdown).not.toContain('```bash')
+    })
+
     it('should preserve multiline code', () => {
       const html = '<pre><code>line1\nline2\nline3</code></pre>'
       const markdown = htmlToMarkdown(html)

--- a/packages/core/src/lib/turndown.ts
+++ b/packages/core/src/lib/turndown.ts
@@ -244,6 +244,29 @@ function normalizeCellContent(content: string): string {
 }
 
 /**
+ * 从 pre/code 元素的属性中提取代码语言。
+ * 多平台页面会把语言放在 data-lang、class、data-language 或 CSDN 的 language-* class 中。
+ */
+function detectCodeLanguage(pre: Element): string {
+  const elements = [pre, pre.querySelector('code')].filter(Boolean) as Element[]
+
+  for (const el of elements) {
+    const attrLanguage =
+      el.getAttribute('data-lang') ||
+      el.getAttribute('data-language') ||
+      el.getAttribute('lang') ||
+      ''
+    if (attrLanguage) return attrLanguage
+
+    const className = el.className || ''
+    const lang = extractLangFromClass(className)
+    if (lang) return lang
+  }
+
+  return ''
+}
+
+/**
  * 表格单元格处理
  */
 function cell(content: string, node: Element): string {
@@ -397,36 +420,7 @@ function addExtensionRules(turndownService: TurndownService): void {
     replacement: function(_content, node) {
       const pre = node as HTMLPreElement
 
-      // 尝试获取语言（多种来源）
-      let language = ''
-      // 1. 从 pre 的 data-lang 属性获取
-      const dataLang = pre.getAttribute('data-lang')
-      if (dataLang) {
-        language = dataLang
-      }
-      // 2. 从 code 的 class 获取
-      if (!language) {
-        const code = pre.querySelector('code')
-        if (code) {
-          const className = code.className || ''
-          const langMatch = className.match(/language-(\w+)/)
-          if (langMatch) {
-            language = langMatch[1]
-          }
-        }
-      }
-      // 3. 从 pre 的 class 获取
-      if (!language) {
-        const preClassName = pre.className || ''
-        const preLangMatch = preClassName.match(/language-(\w+)/)
-        if (preLangMatch) {
-          language = preLangMatch[1]
-        }
-      }
-      // 4. 默认使用 bash
-      if (!language) {
-        language = 'bash'
-      }
+      let language = detectCodeLanguage(pre)
 
       // 处理微信等平台将每行代码放在单独 <code> 标签的情况
       const codeElements = pre.querySelectorAll('code')
@@ -454,7 +448,7 @@ function addExtensionRules(turndownService: TurndownService): void {
         return ''
       }
 
-      // 清理语言标识（只保留字母数字和常见字符）
+      // 清理语言标识（只保留字母数字和常见字符）。无语言时保持空 fence，避免误标成 bash。
       language = language.replace(/[^a-zA-Z0-9+#._-]/g, '').toLowerCase()
 
       // 检测内容中最长的连续反引号，使用更多反引号包裹

--- a/packages/extension/src/content/extractor.ts
+++ b/packages/extension/src/content/extractor.ts
@@ -683,6 +683,21 @@ const SITE_CONFIGS: SiteExtractConfig[] = [
     removeSelectors: ['.anchor', 'a[aria-hidden="true"]', '[data-testid]', '.octicon', '.zeroclipboard-container', '.btn-octicon'],
     unwrapHeadingSelectors: ['.markdown-heading'],
   },
+  {
+    domains: ['csdn.net'],
+    platform: 'csdn',
+    contentSelector: '#content_views, .markdown_views, .htmledit_views, article',
+    titleSelectors: ['.title-article', '#articleContentId', 'h1'],
+    removeSelectors: [
+      '.hide-preCode-box',
+      '.pre-numbering',
+      '.code-toolbar .toolbar',
+      '.blog-tags-box',
+      '.article-info-box',
+      '.recommend-box',
+      '.comment-box',
+    ],
+  },
   // 飞书/Lark 使用虚拟滚动，由 extractFeishuArticle() 通过 fetch + clientVars 解析提取
 ]
 
@@ -1107,7 +1122,8 @@ function preprocessForMultiplePlatformsLocal(
  */
 window.addEventListener('message', async (event) => {
   try {
-    const data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data
+    const data = parseWindowMessage(event.data)
+    if (!data?.type) return
 
     if (data.type === 'CLOSE_EDITOR') {
       closeEditor()
@@ -1150,6 +1166,23 @@ window.addEventListener('message', async (event) => {
     logger.error('Error handling editor message:', e)
   }
 })
+
+function parseWindowMessage(data: unknown): any | null {
+  if (typeof data !== 'string') {
+    return data && typeof data === 'object' ? data : null
+  }
+
+  const trimmed = data.trim()
+  if (!trimmed || (trimmed[0] !== '{' && trimmed[0] !== '[')) {
+    return null
+  }
+
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return null
+  }
+}
 
 /**
  * 监听 background 消息，转发同步进度到编辑器

--- a/packages/extension/src/lib/content-processor.ts
+++ b/packages/extension/src/lib/content-processor.ts
@@ -88,6 +88,14 @@ export function preprocessForPlatform(rawHtml: string, config: PreprocessConfig)
     processLazyImages(container)
   }
 
+  if (config.normalizeLists) {
+    normalizeLists(container)
+  }
+
+  if (config.linearizeTocLists) {
+    linearizeTocLists(container)
+  }
+
   if (config.removeEmptyElements) {
     removeEmptyElements(container)
   }
@@ -561,7 +569,7 @@ function detectCodeLang(pre: Element): string | null {
     if (dataLang) return dataLang.trim().toLowerCase()
 
     // class="language-xxx" / "lang-xxx" / "highlight-xxx"
-    const match = el.className.match(/(?:language|lang|highlight)-(\w+)/)
+    const match = el.className.match(/(?:language|lang|highlight)-([a-zA-Z0-9+#._-]+)/)
     if (match) return match[1].toLowerCase()
 
     // 微信 class="code-snippet__js" 等
@@ -577,6 +585,297 @@ function detectCodeLang(pre: Element): string | null {
  */
 export function preprocessCodeBlocks(container: HTMLElement): void {
   processCodeBlocks(container)
+}
+
+function normalizeLists(container: HTMLElement): void {
+  for (let i = 0; i < 5; i++) {
+    let changed = 0
+    const lists = Array.from(container.querySelectorAll('ul, ol'))
+
+    for (const list of lists) {
+      let previousLi: HTMLElement | null = null
+
+      for (const node of Array.from(list.childNodes)) {
+        if (node.nodeType === Node.TEXT_NODE) {
+          if (!node.textContent?.trim()) {
+            node.remove()
+            changed++
+          }
+          continue
+        }
+
+        if (node.nodeType !== Node.ELEMENT_NODE) continue
+
+        const el = node as HTMLElement
+        if (el.tagName === 'LI') {
+          normalizeListItem(el)
+          if (isEmptyListItem(el)) {
+            el.remove()
+            previousLi = null
+            changed++
+            continue
+          }
+          if (!hasDirectListItemContent(el) && hasDirectNestedList(el)) {
+            flattenNestedListsFromItem(el, list)
+            el.remove()
+            previousLi = null
+            changed++
+            continue
+          }
+          previousLi = el
+          continue
+        }
+
+        if (el.tagName === 'UL' || el.tagName === 'OL') {
+          if (previousLi && hasDirectListItemContent(previousLi)) {
+            previousLi.appendChild(el)
+          } else {
+            if (previousLi && isEmptyListItem(previousLi)) {
+              previousLi.remove()
+            }
+            flattenListIntoParent(el, list)
+            previousLi = null
+          }
+          changed++
+        }
+      }
+    }
+
+    if (changed === 0) break
+  }
+}
+
+function linearizeTocLists(container: HTMLElement): void {
+  const headings = Array.from(container.querySelectorAll('h1, h2, h3, h4, h5, h6, p, div, section'))
+    .filter((el) => normalizeText(el.textContent || '') === '文章目录')
+
+  for (const heading of headings) {
+    const tocList = findFollowingList(heading)
+    if (!tocList) continue
+
+    const tocEntries = collectTocEntries(tocList, 0)
+    const wrapper = buildTocList(tocEntries)
+
+    if (wrapper.childNodes.length > 0) {
+      tocList.replaceWith(wrapper)
+    }
+  }
+}
+
+function findFollowingList(start: Element): HTMLElement | null {
+  let current = start.nextElementSibling as HTMLElement | null
+
+  while (current) {
+    if (current.tagName === 'UL' || current.tagName === 'OL') return current
+
+    const directList = Array.from(current.children)
+      .find((child) => child.tagName === 'UL' || child.tagName === 'OL') as HTMLElement | undefined
+    if (directList) return directList
+
+    if (/^H[1-6]$/.test(current.tagName)) return null
+    if (normalizeText(current.textContent || '') && !current.querySelector('ul, ol')) return null
+
+    current = current.nextElementSibling as HTMLElement | null
+  }
+
+  return null
+}
+
+interface TocEntry {
+  text: string
+  depth: number
+}
+
+function collectTocEntries(list: Element, fallbackDepth: number): TocEntry[] {
+  const entries: TocEntry[] = []
+
+  for (const item of Array.from(list.children)) {
+    if (item.tagName !== 'LI') continue
+
+    const text = getListItemDirectText(item as HTMLElement)
+    if (text) {
+      entries.push({
+        text,
+        depth: detectTocDepth(text, fallbackDepth),
+      })
+    }
+
+    for (const childList of Array.from(item.children).filter((child) => child.tagName === 'UL' || child.tagName === 'OL')) {
+      entries.push(...collectTocEntries(childList, fallbackDepth + 1))
+    }
+  }
+
+  return entries
+}
+
+function buildTocList(entries: TocEntry[]): HTMLElement {
+  const root = document.createElement('ul')
+  root.setAttribute('data-wechatsync-toc', 'true')
+
+  const listStack: HTMLElement[] = [root]
+  const itemStack: HTMLElement[] = []
+
+  for (const entry of entries) {
+    const depth = Math.max(0, Math.min(entry.depth, itemStack.length))
+
+    while (listStack.length > depth + 1) {
+      listStack.pop()
+    }
+
+    while (listStack.length < depth + 1) {
+      const parentItem = itemStack[listStack.length - 2]
+      if (!parentItem) break
+      const childList = document.createElement('ul')
+      childList.style.margin = '0.35em 0 0.35em 0'
+      childList.style.paddingLeft = '1.5em'
+      parentItem.appendChild(childList)
+      listStack.push(childList)
+    }
+
+    const item = document.createElement('li')
+    item.style.margin = '0 0 0.35em 0'
+    item.style.fontSize = '15px'
+    item.style.lineHeight = '1.75em'
+    item.textContent = entry.text
+    listStack[listStack.length - 1].appendChild(item)
+    itemStack[depth] = item
+    itemStack.length = depth + 1
+  }
+
+  return root
+}
+
+function detectTocDepth(text: string, fallbackDepth: number): number {
+  const numericPrefix = text.match(/^(\d+(?:\.\d+)+)\b/)
+  if (numericPrefix) {
+    return numericPrefix[1].split('.').length - 1
+  }
+
+  if (/^[一二三四五六七八九十]+[、.．]/.test(text)) {
+    return 0
+  }
+
+  return fallbackDepth
+}
+
+function getListItemDirectText(li: HTMLElement): string {
+  const clone = li.cloneNode(true) as HTMLElement
+  clone.querySelectorAll('ul, ol').forEach((list) => list.remove())
+  return normalizeText(clone.textContent || '')
+}
+
+function normalizeText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+function normalizeListItem(li: HTMLElement): void {
+  removeEmptyListItemChildren(li)
+  unwrapSimpleListItemBlocks(li)
+  collapseDirectListItemBreaks(li)
+  normalizeDirectListItemTextNodes(li)
+  moveNestedListsToEnd(li)
+}
+
+function removeEmptyListItemChildren(li: HTMLElement): void {
+  for (const child of Array.from(li.children)) {
+    if (!['P', 'DIV', 'SECTION', 'SPAN'].includes(child.tagName)) continue
+    if (child.querySelector('img, video, audio, iframe, canvas, svg, ul, ol')) continue
+    if (!child.textContent?.trim()) {
+      child.remove()
+    }
+  }
+}
+
+function collapseDirectListItemBreaks(li: HTMLElement): void {
+  if (li.querySelector('pre, table, blockquote')) return
+
+  for (const node of Array.from(li.childNodes)) {
+    if (node.nodeType === Node.ELEMENT_NODE && (node as Element).tagName === 'BR') {
+      node.replaceWith(document.createTextNode(' '))
+    }
+  }
+}
+
+function normalizeDirectListItemTextNodes(li: HTMLElement): void {
+  if (li.querySelector('pre, table, blockquote')) return
+
+  for (const node of Array.from(li.childNodes)) {
+    if (node.nodeType === Node.TEXT_NODE && node.textContent) {
+      node.textContent = node.textContent.replace(/\s+/g, ' ')
+    }
+  }
+}
+
+function unwrapSimpleListItemBlocks(li: HTMLElement): void {
+  for (const child of Array.from(li.children)) {
+    if (!['P', 'DIV', 'SECTION'].includes(child.tagName)) continue
+    if (child.querySelector('ul, ol, table, pre, blockquote, img, video, audio, iframe, canvas, svg')) continue
+
+    const hasText = !!child.textContent?.trim()
+    if (child.previousSibling && hasText) {
+      li.insertBefore(document.createTextNode(' '), child)
+    }
+    child.querySelectorAll('br').forEach((br) => br.replaceWith(document.createTextNode(' ')))
+    while (child.firstChild) {
+      li.insertBefore(child.firstChild, child)
+    }
+    if (child.nextSibling && hasText) {
+      li.insertBefore(document.createTextNode(' '), child)
+    }
+    child.remove()
+  }
+}
+
+function moveNestedListsToEnd(li: HTMLElement): void {
+  const nestedLists = Array.from(li.children).filter((child) => child.tagName === 'UL' || child.tagName === 'OL')
+  for (const nestedList of nestedLists) {
+    li.appendChild(nestedList)
+  }
+}
+
+function flattenListIntoParent(childList: Element, parentList: Element): void {
+  const items = Array.from(childList.children).filter((child) => child.tagName === 'LI')
+  for (const item of items) {
+    normalizeListItem(item as HTMLElement)
+    parentList.insertBefore(item, childList)
+  }
+  childList.remove()
+}
+
+function flattenNestedListsFromItem(li: HTMLElement, parentList: Element): void {
+  const nestedLists = Array.from(li.children).filter((child) => child.tagName === 'UL' || child.tagName === 'OL')
+  for (const nestedList of nestedLists) {
+    const items = Array.from(nestedList.children).filter((child) => child.tagName === 'LI')
+    for (const item of items) {
+      normalizeListItem(item as HTMLElement)
+      parentList.insertBefore(item, li)
+    }
+  }
+}
+
+function hasDirectListItemContent(li: HTMLElement): boolean {
+  return Array.from(li.childNodes).some((node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      return !!node.textContent?.trim()
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE) return false
+
+    const el = node as HTMLElement
+    if (el.tagName === 'UL' || el.tagName === 'OL') return false
+    if (el.querySelector('img, video, audio, iframe, canvas, svg')) return true
+    return !!el.textContent?.trim()
+  })
+}
+
+function isEmptyListItem(li: HTMLElement): boolean {
+  const hasNestedList = hasDirectNestedList(li)
+  const hasMedia = !!li.querySelector('img, video, audio, iframe, canvas, svg')
+  return !hasNestedList && !hasMedia && !hasDirectListItemContent(li)
+}
+
+function hasDirectNestedList(li: HTMLElement): boolean {
+  return Array.from(li.children).some((child) => child.tagName === 'UL' || child.tagName === 'OL')
 }
 
 /**

--- a/packages/extension/src/lib/content-processor.ts
+++ b/packages/extension/src/lib/content-processor.ts
@@ -89,7 +89,9 @@ export function preprocessForPlatform(rawHtml: string, config: PreprocessConfig)
   }
 
   if (config.normalizeLists) {
-    normalizeLists(container)
+    normalizeLists(container, {
+      flattenListItemText: !!config.flattenListItemText,
+    })
   }
 
   if (config.linearizeTocLists) {
@@ -587,7 +589,11 @@ export function preprocessCodeBlocks(container: HTMLElement): void {
   processCodeBlocks(container)
 }
 
-function normalizeLists(container: HTMLElement): void {
+interface ListNormalizeOptions {
+  flattenListItemText: boolean
+}
+
+function normalizeLists(container: HTMLElement, options: ListNormalizeOptions): void {
   for (let i = 0; i < 5; i++) {
     let changed = 0
     const lists = Array.from(container.querySelectorAll('ul, ol'))
@@ -608,7 +614,7 @@ function normalizeLists(container: HTMLElement): void {
 
         const el = node as HTMLElement
         if (el.tagName === 'LI') {
-          normalizeListItem(el)
+          normalizeListItem(el, options)
           if (isEmptyListItem(el)) {
             el.remove()
             previousLi = null
@@ -712,34 +718,13 @@ function buildTocList(entries: TocEntry[]): HTMLElement {
   const root = document.createElement('ul')
   root.setAttribute('data-wechatsync-toc', 'true')
 
-  const listStack: HTMLElement[] = [root]
-  const itemStack: HTMLElement[] = []
-
   for (const entry of entries) {
-    const depth = Math.max(0, Math.min(entry.depth, itemStack.length))
-
-    while (listStack.length > depth + 1) {
-      listStack.pop()
-    }
-
-    while (listStack.length < depth + 1) {
-      const parentItem = itemStack[listStack.length - 2]
-      if (!parentItem) break
-      const childList = document.createElement('ul')
-      childList.style.margin = '0.35em 0 0.35em 0'
-      childList.style.paddingLeft = '1.5em'
-      parentItem.appendChild(childList)
-      listStack.push(childList)
-    }
-
     const item = document.createElement('li')
     item.style.margin = '0 0 0.35em 0'
     item.style.fontSize = '15px'
     item.style.lineHeight = '1.75em'
-    item.textContent = entry.text
-    listStack[listStack.length - 1].appendChild(item)
-    itemStack[depth] = item
-    itemStack.length = depth + 1
+    item.textContent = `${'\u3000'.repeat(Math.max(0, entry.depth) * 2)}${entry.text}`
+    root.appendChild(item)
   }
 
   return root
@@ -768,11 +753,14 @@ function normalizeText(text: string): string {
   return text.replace(/\s+/g, ' ').trim()
 }
 
-function normalizeListItem(li: HTMLElement): void {
+function normalizeListItem(li: HTMLElement, options: ListNormalizeOptions): void {
   removeEmptyListItemChildren(li)
   unwrapSimpleListItemBlocks(li)
   collapseDirectListItemBreaks(li)
   normalizeDirectListItemTextNodes(li)
+  if (options.flattenListItemText) {
+    flattenSimpleListItemText(li)
+  }
   moveNestedListsToEnd(li)
 }
 
@@ -806,6 +794,22 @@ function normalizeDirectListItemTextNodes(li: HTMLElement): void {
   }
 }
 
+function flattenSimpleListItemText(li: HTMLElement): void {
+  if (li.querySelector('pre, table, blockquote, img, video, audio, iframe, canvas, svg')) return
+
+  const nestedLists = Array.from(li.children).filter((child) => child.tagName === 'UL' || child.tagName === 'OL')
+  const clone = li.cloneNode(true) as HTMLElement
+  clone.querySelectorAll('ul, ol').forEach((list) => list.remove())
+
+  const text = normalizeText(clone.textContent || '')
+  if (!text) return
+
+  li.textContent = text
+  for (const nestedList of nestedLists) {
+    li.appendChild(nestedList)
+  }
+}
+
 function unwrapSimpleListItemBlocks(li: HTMLElement): void {
   for (const child of Array.from(li.children)) {
     if (!['P', 'DIV', 'SECTION'].includes(child.tagName)) continue
@@ -836,7 +840,7 @@ function moveNestedListsToEnd(li: HTMLElement): void {
 function flattenListIntoParent(childList: Element, parentList: Element): void {
   const items = Array.from(childList.children).filter((child) => child.tagName === 'LI')
   for (const item of items) {
-    normalizeListItem(item as HTMLElement)
+    normalizeListItem(item as HTMLElement, { flattenListItemText: false })
     parentList.insertBefore(item, childList)
   }
   childList.remove()
@@ -847,7 +851,7 @@ function flattenNestedListsFromItem(li: HTMLElement, parentList: Element): void 
   for (const nestedList of nestedLists) {
     const items = Array.from(nestedList.children).filter((child) => child.tagName === 'LI')
     for (const item of items) {
-      normalizeListItem(item as HTMLElement)
+      normalizeListItem(item as HTMLElement, { flattenListItemText: false })
       parentList.insertBefore(item, li)
     }
   }

--- a/packages/extension/src/lib/reader/index.ts
+++ b/packages/extension/src/lib/reader/index.ts
@@ -156,6 +156,32 @@ function escapeHtml(text: string): string {
     .replace(/'/g, '&#039;')
 }
 
+function detectCodeLang(pre: Element): string {
+  const elements = [pre, pre.querySelector('code')].filter(Boolean) as Element[]
+
+  for (const el of elements) {
+    const attrLang =
+      el.getAttribute('data-lang') ||
+      el.getAttribute('data-language') ||
+      el.getAttribute('lang') ||
+      ''
+    if (attrLang) return attrLang.trim().toLowerCase()
+
+    const className = el.className || ''
+    const patterns = [
+      /(?:language|lang|highlight)-([a-zA-Z0-9+#._-]+)/,
+      /\bhljs\s+([a-zA-Z0-9+#._-]+)/,
+      /\b(javascript|typescript|python|java|cpp|c|csharp|go|rust|ruby|php|swift|kotlin|scala|sql|html|css|json|xml|yaml|markdown|bash|shell|powershell)\b/i,
+    ]
+    for (const pattern of patterns) {
+      const match = className.match(pattern)
+      if (match) return match[1].toLowerCase()
+    }
+  }
+
+  return ''
+}
+
 /**
  * 临时简化页面中的代码块，返回备份以便恢复
  * 使用真实 DOM 提取代码（保留换行）
@@ -214,8 +240,14 @@ function backupAndReplaceCodeBlocks(): ElementBackup[] {
       originalHTML: pre.innerHTML,
     })
 
-    // 替换为纯文本
+    const lang = detectCodeLang(pre)
+
+    // 替换为纯文本，同时保留语言给后续 HTML→Markdown 转换使用。
     pre.innerHTML = `<code>${escapeHtml(cleanedText)}</code>`
+    if (lang) {
+      pre.setAttribute('data-lang', lang)
+      pre.className = `language-${lang}`
+    }
   })
 
   return backups


### PR DESCRIPTION
## Background

When syncing articles from CSDN browser pages to Zhihu, Juejin and WeChat Official Account, several formatting issues appeared even though the original CSDN page rendered correctly:

- Code block languages were lost or normalized incorrectly.
- Juejin code blocks without a detected language became `bash`.
- WeChat imported CSDN TOC/list structures with wrong order, empty list items, lost indentation, extra line breaks, inconsistent font sizes, and collapsed code line breaks.
- Juejin draft cover and summary were not populated.

## Root Cause

CSDN-rendered HTML is display-friendly but not always editor-friendly. Some TOC/list structures contain nested or adjacent list markup that rich-text editors reinterpret differently. WeChat editor also sanitizes list styles and treats simple `p/div/br` blocks inside list items as separate paragraphs, which can create extra line breaks or flatten indentation during import.

## Changes

- Preserve code block language from `pre/code` attributes and class names.
- Stop defaulting unknown fenced code language to `bash`.
- Add CSDN-specific extraction selectors and cleanup rules.
- Add list normalization for platform preprocessing.
- For WeChat:
  - Normalize list structures.
  - Convert CSDN TOC nested lists into stable single-level list items.
  - Preserve TOC visual indentation with text-level full-width spacing instead of editor-sanitized CSS indentation.
  - Flatten simple `p/div/section/br` wrappers inside list items.
  - Add stable font sizing for list and table content.
  - Normalize code blocks into line-preserving rich-text-friendly markup.
  - Use extension runtime fetch when downloading remote images before upload.
- For Zhihu:
  - Preserve code block language attributes.
  - Add list normalization.
  - Preserve blockquote semantics for Draft.js.
- For Juejin:
  - Upload and set draft cover image when available.
  - Fill `brief_content` from extracted article summary.
- Add tests for code language preservation and unknown-language handling.

## Verification

- `pnpm --filter @wechatsync/core typecheck`
- `pnpm --filter @wechatsync/extension typecheck`
- `pnpm --filter @wechatsync/core test -- --run`
- `pnpm --filter @wechatsync/extension build`